### PR TITLE
Add base Version classes

### DIFF
--- a/src/arti/graphs/core.py
+++ b/src/arti/graphs/core.py
@@ -10,6 +10,9 @@ from arti.internal.utils import TypedBox
 ArtifactBox = TypedBox[Artifact]
 
 
+# TODO: When building out run logic, resolve and statically set all available fingerprints.
+# Specifically, we should pin the Producer.fingerprint, which may by dynamic (eg: version is a
+# Timestamp). Unbuilt Artifact (partitions) won't be fully resolved yet.
 class Graph:
     """ Graph stores a web of Artifacts connected by Producers.
     """

--- a/src/arti/versions/core.py
+++ b/src/arti/versions/core.py
@@ -1,0 +1,83 @@
+import inspect
+import os
+import subprocess
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, Optional, cast
+
+from arti.fingerprints.core import Fingerprint
+from arti.internal.utils import qname
+
+
+class Version:
+    @property
+    def fingerprint(self) -> Fingerprint:
+        raise NotImplementedError(f"{qname(self)}.fingerprint is not implemented!")
+
+
+class GitCommit(Version):
+    def __init__(self, *, envvar: str = "GIT_SHA"):
+        if (sha := os.environ.get(envvar)) is None:
+            sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+        self.sha = sha
+
+    @property
+    def fingerprint(self) -> Fingerprint:
+        return Fingerprint.from_string(self.sha)
+
+
+class SemVer(Version):
+    """ SemVer fingerprinting only considers the major component, unless it is less than 0.
+
+        By only considering the major version, we can add incremental bumps to a Producer without triggering
+        historical backfills. The major version MUST be incremented on schema or methodological changes.
+    """
+
+    def __init__(self, major: int, minor: int, patch: int):
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+
+    @property
+    def fingerprint(self) -> Fingerprint:
+        s = str(self.major)
+        if self.major == 0:
+            s = f"{self.major}.{self.minor}.{self.patch}"
+        return Fingerprint.from_string(s)
+
+
+class String(Version):
+    def __init__(self, value: str):
+        self.value = value
+
+    @property
+    def fingerprint(self) -> Fingerprint:
+        return Fingerprint.from_string(self.value)
+
+
+class _SourceDescriptor:  # Experimental :)
+    # Using AST rather than literal source will likely be less "noisy":
+    #     https://github.com/replicahq/artigraph/pull/36#issuecomment-824131156
+    def __get__(self, obj: Any, type_: type) -> String:
+        return String(inspect.getsource(type_))
+
+
+_Source = cast(Callable[[], String], _SourceDescriptor)
+
+
+class Timestamp(Version):
+    def __init__(self, dt: Optional[datetime] = None):
+        if dt is not None and dt.tzinfo is None:
+            raise ValueError("Timestamp requires a timezone-aware datetime!")
+        self.dt = dt
+
+    @property
+    def fingerprint(self) -> Fingerprint:
+        return Fingerprint.from_int(round((self.dt or datetime.utcnow()).timestamp()))
+
+
+# TODO: Consider a Timestamp like version with a "frequency" arg (day, hour, etc) that we floor/ceil
+# to trigger "scheduled" invalidation. This doesn't solve imperative work like "process X every hour
+# on the hour and play catch up for missed runs" (rather, we should aim to represent that with
+# upstream Artifact partitions), but rather solves work like "ingest all data at most this
+# frequently" (eg: full export from an API - no point in a backfill).

--- a/tests/arti/producers/test_producer.py
+++ b/tests/arti/producers/test_producer.py
@@ -2,7 +2,9 @@ from typing import Any
 
 import pytest
 
+from arti.fingerprints.core import Fingerprint
 from arti.producers.core import Producer
+from arti.versions.core import String
 from tests.arti.dummies import A1, A2, A3, A4, P1, P2
 
 
@@ -22,6 +24,13 @@ def test_Producer() -> None:
     expected_output_classes = [A2, A3]
     for i, output in enumerate(producer):
         assert isinstance(output, expected_output_classes[i])
+
+
+def test_Producer_fingerprint() -> None:
+    p1 = P1(a1=A1())
+    assert p1.fingerprint == Fingerprint.from_string("P1") ^ p1.version.fingerprint
+    p1.key, p1.version = "abc", String("xyz")
+    assert p1.fingerprint == Fingerprint.from_string("abc") ^ String("xyz").fingerprint
 
 
 def test_Producer_out() -> None:

--- a/tests/arti/versions/test_version.py
+++ b/tests/arti/versions/test_version.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from arti.versions.core import GitCommit, SemVer, String, Timestamp, Version, _Source
+
+
+def test_GitCommit() -> None:
+    # Prefer env var
+    with patch.dict("os.environ", values={"GIT_SHA": "test"}):
+        ver = GitCommit()
+        assert ver.sha == "test"
+        assert ver.fingerprint == 8581389452482819506
+    # Change default env var name
+    with patch.dict("os.environ", values={"GIT_COMMIT": "test"}):
+        ver = GitCommit(envvar="GIT_COMMIT")
+        assert ver.sha == "test"
+        assert ver.fingerprint == 8581389452482819506
+    # Without env var, fall back to `git rev-parse`
+    assert len(GitCommit(envvar="non-existent").sha) == 40
+
+
+@pytest.mark.parametrize(
+    ["major", "minor", "patch", "fingerprint"],
+    (
+        (0, 0, 0, -4875916080982812485),
+        (0, 0, 1, -6022020963282911891),
+        (0, 1, 0, -612532240571011082),
+        (0, 1, 1, -1388070919761090296),
+        # Major versions >=1 fingerprint the major alone
+        (1, 0, 0, -9142586270102516767),
+        (1, 0, 1, -9142586270102516767),
+        (1, 1, 0, -9142586270102516767),
+        (1, 1, 1, -9142586270102516767),
+        (2, 0, 0, 6920640749119438759),
+        (2, 5, 5, 6920640749119438759),
+    ),
+)
+def test_SemVer(major: int, minor: int, patch: int, fingerprint: int) -> None:
+    assert SemVer(major, minor, patch).fingerprint == fingerprint
+
+
+def test__Source() -> None:
+    class P:
+        version: Version = _Source()
+
+    assert isinstance(P.version, String)
+    assert P.version.value == "    class P:\n        version: Version = _Source()\n"
+    assert P.version.fingerprint == -4528092110694557253
+    assert P().version.fingerprint == -4528092110694557253
+
+    class P2:
+        version = _Source()
+
+    assert P.version.fingerprint != P2.version.fingerprint
+
+
+def test_String() -> None:
+    assert String("ok").fingerprint == 5227454011934222951
+
+
+def test_Timestamp() -> None:
+    d = datetime.now(tz=timezone.utc)
+    assert Timestamp(d).fingerprint == round(d.timestamp())
+    # Check the default is ~now.
+    key, now = Timestamp().fingerprint.key, round(datetime.utcnow().timestamp())
+    assert key is not None
+    assert now - 1 <= key <= now + 1
+    # Confirm naive datetime are not supported
+    with pytest.raises(ValueError):
+        Timestamp(datetime.now())
+
+
+def test_Version() -> None:
+    with pytest.raises(NotImplementedError):
+        Version().fingerprint


### PR DESCRIPTION
Adds the base Version class with a few starter implementations representing different strategies for a Producer:
- GitCommit: change version automatically based on the git commit
- SemVer: a "major.minor.patch" tuple following (my skimming of) https://semver.org/
    - `<1.0.0` hashes all components 
    - `>=1.0.0` hashes only the major component
- String: arbitrary version string
- Timestamp: Unix seconds
- _Source: an experimental strategy that fingerprints the Producer's source code definition (:exploding_head:... cc @mikss)

Tagged a few others to get more ideas around these and other strategies.
