### PR TITLE
Add TypeAdapter.matches_* methods and expand tests

### DIFF
--- a/src/arti/formats/core.py
+++ b/src/arti/formats/core.py
@@ -18,5 +18,5 @@ class Format(Model):
 
     def validate_artifact(self, schema: Optional[Type]) -> None:
         # TODO: Check self.type_system supports the schema. We can likely add a TypeSystem method
-        # that will check for matching TypeAdaptors.
+        # that will check for matching TypeAdapters.
         pass

--- a/src/arti/types/python.py
+++ b/src/arti/types/python.py
@@ -4,18 +4,29 @@ from typing import Any
 
 from arti.types.core import Int64, Type, TypeAdapter, TypeSystem
 
-python = TypeSystem(key="python", system_metaclass=True)
+python = TypeSystem(key="python")
 
 
-@python.register_adapter
-class PyInt64(TypeAdapter):
-    external = int
-    internal = Int64
+# Python types are all instances of `type` - there is no "meaningful" metaclass. Hence, we must
+# match on and return the type identity.
+class _SingletonTypeAdapter(TypeAdapter):
+    @classmethod
+    def to_artigraph(cls, type_: Any) -> Type:
+        return cls.artigraph()
 
     @classmethod
-    def to_external(cls, type_: Type) -> Any:
-        return cls.external
+    def matches_system(cls, type_: Any) -> bool:
+        return type_ is cls.system
 
     @classmethod
-    def to_internal(cls, type_: Any) -> Type:
-        return cls.internal()
+    def to_system(cls, type_: Type) -> Any:
+        return cls.system
+
+
+def _gen_adapter(name: str, *, artigraph: type[Type], system: Any) -> type[TypeAdapter]:
+    return python.register_adapter(
+        type(name, (_SingletonTypeAdapter,), {"artigraph": artigraph, "system": system})
+    )
+
+
+_gen_adapter("PyInt64", artigraph=Int64, system=int)

--- a/tests/arti/types/test_types.py
+++ b/tests/arti/types/test_types.py
@@ -1,7 +1,73 @@
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
-from arti.types.core import Int32, Int64, Struct, Timestamp, Type, TypeAdapter, TypeSystem
+from arti.types.core import (
+    Float16,
+    Float32,
+    Float64,
+    Int32,
+    Int64,
+    Struct,
+    Timestamp,
+    Type,
+    TypeAdapter,
+    TypeSystem,
+)
+
+
+class MyFloat(float):
+    pass
+
+
+class MyInt(int):
+    pass
+
+
+def _gen_numeric_adapter(
+    artigraph_type: type[Type], system_type: Any, precision: int
+) -> type[TypeAdapter]:
+    class Adapter(TypeAdapter):
+        key = f"{artigraph_type.__class_key__}Adapter"
+        artigraph = artigraph_type
+        system = system_type
+
+        priority = precision
+
+        @classmethod
+        def to_artigraph(cls, type_: Any) -> Type:
+            return cls.artigraph()
+
+        @classmethod
+        def matches_system(cls, type_: Any) -> bool:
+            return type_ is cls.system
+
+        @classmethod
+        def to_system(cls, type_: Type) -> Any:
+            return cls.system
+
+    return Adapter
+
+
+@pytest.fixture(scope="session")
+def Float16Adapter() -> type[TypeAdapter]:
+    return _gen_numeric_adapter(artigraph_type=Float16, system_type=MyFloat, precision=16)
+
+
+@pytest.fixture(scope="session")
+def Float32Adapter() -> type[TypeAdapter]:
+    return _gen_numeric_adapter(artigraph_type=Float32, system_type=MyFloat, precision=32)
+
+
+@pytest.fixture(scope="session")
+def Float64Adapter() -> type[TypeAdapter]:
+    return _gen_numeric_adapter(artigraph_type=Float64, system_type=MyFloat, precision=64)
+
+
+@pytest.fixture(scope="session")
+def Int32Adapter() -> type[TypeAdapter]:
+    return _gen_numeric_adapter(artigraph_type=Int32, system_type=MyInt, precision=32)
 
 
 def test_Type() -> None:
@@ -25,24 +91,43 @@ def test_Timestamp() -> None:
     assert Timestamp(precision="millisecond").precision == "millisecond"
 
 
-def test_TypeSystem() -> None:
-    python = TypeSystem(key="python")
-    assert python.key == "python"
-    with pytest.raises(NotImplementedError):
-        python.from_core(Int32())
-    with pytest.raises(NotImplementedError):
-        python.to_core(int)
+def test_TypeSystem(
+    Float16Adapter: type[TypeAdapter],
+    Float32Adapter: type[TypeAdapter],
+    Float64Adapter: type[TypeAdapter],
+    Int32Adapter: type[TypeAdapter],
+) -> None:
+    dummy = TypeSystem(key="dummy")
+    assert dummy.key == "dummy"
 
-    @python.register_adapter
-    class PyInt32(TypeAdapter):
-        external = int
-        internal = Int32
+    with pytest.raises(NotImplementedError):
+        dummy.to_system(Float32())
+    with pytest.raises(NotImplementedError):
+        dummy.to_artigraph(MyFloat)
+    # Register adapters sequentially. With a single matching adapter registered, we expect the
+    # matching type. With conflicting matching adapters registered, we expect the type of the
+    # adapter with the highest priority.
+    for adapter, artigraph_type in [
+        (Float32Adapter, Float32),
+        (Float16Adapter, Float32),
+        (Float64Adapter, Float64),
+    ]:
+        # Register a single adapter
+        dummy.register_adapter(adapter)
+        assert isinstance(dummy.to_artigraph(MyFloat), artigraph_type)
+        assert dummy.to_system(artigraph_type()) is MyFloat
 
-    assert PyInt32.key == "PyInt32"
+    with pytest.raises(NotImplementedError):
+        assert isinstance(dummy.to_artigraph(MyInt), Int32)
+    with pytest.raises(NotImplementedError):
+        assert dummy.to_system(Int32()) is MyInt
+    dummy.register_adapter(Int32Adapter)
+    assert isinstance(dummy.to_artigraph(MyInt), Int32)
+    assert dummy.to_system(Int32()) is MyInt
 
 
 def test_python_TypeSystem() -> None:
     from arti.types.python import python
 
-    assert isinstance(python.to_core(int), Int64)
-    assert python.from_core(Int64()) is int
+    assert isinstance(python.to_artigraph(int), Int64)
+    assert python.to_system(Int64()) is int


### PR DESCRIPTION
The `TypeAdapter` matching will need to be a bit more robust/dynamic to support different systems, eg:
- `google.cloud.bigquery`: types are specified within the `field_type` instance attribute of a `SchemaField` class
- `pyarror`: types each have a specific class, which users instantiate to configure
- `python`: types are singletons, each an instance of `type`

To support these different approaches, I extended `TypeAdapter` to add extra `matches_{artigraph,system}` methods that can be overridden a bit more easily. For `TypeSystem(key="python")` specifically, I added a `_SingletonTypeAdapter` and a class generator to ease expanding the _simple_ types (without required arguments, eg: Int32). I'm not sure how well those helpers will generalize, so put them into `types/python.py` specifically for now.

I also tried to fix some of the dissonance w/ the conversion method names between `TypeAdapter` and `TypeSystem`

Follow up from: https://github.com/replicahq/artigraph/pull/58#pullrequestreview-710989348
