### PR TITLE
Rename non-standard dunder attributes to sunder

### DIFF
--- a/src/arti/annotations/core.py
+++ b/src/arti/annotations/core.py
@@ -6,4 +6,4 @@ from arti.internal.models import Model
 class Annotation(Model):
     """An Annotation is a piece of human knowledge associated with an Artifact."""
 
-    __abstract__ = True
+    _abstract_ = True

--- a/src/arti/formats/core.py
+++ b/src/arti/formats/core.py
@@ -13,7 +13,7 @@ class Format(Model):
     Artigraph types and any external type information.
     """
 
-    __abstract__ = True
+    _abstract_ = True
     type_system: ClassVar[TypeSystem]
 
     def validate_artifact(self, schema: Optional[Type]) -> None:

--- a/src/arti/internal/models.py
+++ b/src/arti/internal/models.py
@@ -6,25 +6,25 @@ from arti.internal.utils import class_name
 
 
 class Model(BaseModel):
-    # A model can be marked __abstract__ to prevent direct instantiation, such as when it is
-    # intended as a base class for other models with arbitrary data. As the subclasses of an
-    # __abstract__ model have unknown fields (varying per subclass), we don't have targets to mark
-    # abstract with abc.ABC nor typing.Protocol. See [1] for more context.
+    # A model can be marked _abstract_ to prevent direct instantiation, such as when it is intended
+    # as a base class for other models with arbitrary data. As the subclasses of an _abstract_ model
+    # have unknown fields (varying per subclass), we don't have targets to mark abstract with
+    # abc.ABC nor typing.Protocol. See [1] for more context.
     #
     # 1: https://github.com/replicahq/artigraph/pull/60#discussion_r669089086
-    __abstract__: ClassVar[bool] = True
-    __class_key__: ClassVar[str] = class_name()
+    _abstract_: ClassVar[bool] = True
+    _class_key_: ClassVar[str] = class_name()
 
     @classmethod
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)  # type: ignore # https://github.com/python/mypy/issues/4660
-        # Default __abstract__ to False if not set explicitly on the class. __dict__ is read-only.
-        setattr(cls, "__abstract__", cls.__dict__.get("__abstract__", False))
+        # Default _abstract_ to False if not set explicitly on the class. __dict__ is read-only.
+        setattr(cls, "_abstract_", cls.__dict__.get("_abstract_", False))
 
     @root_validator(pre=True)
     @classmethod
     def _block_abstract_instance(cls, values: dict[str, Any]) -> dict[str, Any]:
-        if cls.__abstract__:
+        if cls._abstract_:
             raise ValueError(f"{cls} cannot be instantiated directly!")
         return values
 

--- a/src/arti/storage/core.py
+++ b/src/arti/storage/core.py
@@ -8,7 +8,7 @@ from arti.types.core import Type
 
 
 class Storage(Model):
-    __abstract__ = True
+    _abstract_ = True
 
     def validate_artifact(self, schema: Optional[Type], format: Optional[Format]) -> None:
         # TODO: Ensure the storage supports all of the specified schema types and partitioning on

--- a/src/arti/types/core.py
+++ b/src/arti/types/core.py
@@ -13,7 +13,7 @@ from arti.internal.utils import class_name, register
 class Type(Model):
     """Type represents a data type."""
 
-    __abstract__ = True
+    _abstract_ = True
     description: Optional[str]
 
 

--- a/src/arti/versions/core.py
+++ b/src/arti/versions/core.py
@@ -13,7 +13,7 @@ from arti.internal.utils import qname
 
 
 class Version(Model):
-    __abstract__ = True
+    _abstract_ = True
 
     @property
     @abstractmethod

--- a/src/arti/views/core.py
+++ b/src/arti/views/core.py
@@ -13,7 +13,7 @@ class View(Model):
     Examples include pandas.DataFrame, dask.DataFrame, a BigQuery table.
     """
 
-    __abstract__ = True
+    _abstract_ = True
     _registry_: ClassVar[dict[type, type[View]]] = dict()
 
     priority: ClassVar[int] = 0  # Set priority of this view for its python_type. Higher is better.
@@ -22,5 +22,5 @@ class View(Model):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if not cls.__abstract__:
+        if not cls._abstract_:
             register(cls._registry_, cls.python_type, cls, lambda x: x.priority)

--- a/src/arti/views/python.py
+++ b/src/arti/views/python.py
@@ -10,7 +10,7 @@ from arti.views.core import View
 
 
 class _PythonBuiltin(View):
-    __abstract__ = True
+    _abstract_ = True
 
     type_system: ClassVar[TypeSystem] = python
 

--- a/tests/arti/internal/test_models.py
+++ b/tests/arti/internal/test_models.py
@@ -7,7 +7,7 @@ from arti.internal.models import Model
 
 
 class Abstract(Model):
-    __abstract__: ClassVar[bool] = True
+    _abstract_: ClassVar[bool] = True
 
 
 class Concrete(Model):

--- a/tests/arti/types/test_types.py
+++ b/tests/arti/types/test_types.py
@@ -29,7 +29,7 @@ def _gen_numeric_adapter(
     artigraph_type: type[Type], system_type: Any, precision: int
 ) -> type[TypeAdapter]:
     class Adapter(TypeAdapter):
-        key = f"{artigraph_type.__class_key__}Adapter"
+        key = f"{artigraph_type._class_key_}Adapter"
         artigraph = artigraph_type
         system = system_type
 

--- a/tests/arti/versions/test_version.py
+++ b/tests/arti/versions/test_version.py
@@ -63,7 +63,7 @@ def test_Timestamp() -> None:
 
 
 def test_Version() -> None:
-    # Version sets an @abstractmethod, so ABC catches it before our Model.__abstract__ validator.
+    # Version sets an @abstractmethod, so ABC catches it before our Model._abstract_ validator.
     with pytest.raises(
         TypeError,
         match="Can't instantiate abstract class Version with abstract method fingerprint",

--- a/tests/arti/views/test_views.py
+++ b/tests/arti/views/test_views.py
@@ -15,7 +15,7 @@ def test_View() -> None:
 
 def test_View_registry() -> None:
     class V(View):
-        __abstract__ = True
+        _abstract_ = True
         _registry_: ClassVar[dict[type, type[View]]] = {}
 
     class Int(V):


### PR DESCRIPTION
We had a handful of custom dunder (`__<name>__`) properties and methods, but those should be reserved for python magics. Instead, taking [a hint from `enum`](https://docs.python.org/3/library/enum.html#supported-sunder-names), I moved all of the custom dunders to sunders (`_<name>_`).
