### PR TITLE
Use pydantic for Producers

### DIFF
--- a/docs/example.py
+++ b/docs/example.py
@@ -32,7 +32,8 @@ class ODs(Artifact):
 class TracesToODs(Producer):
     # This currently takes the Artifact directly, but eventually it'll take a "view" of the artifact (eg: pd.DataFrame)
     # and optionally a "field slice" (eg: [lat, lng, timestamp]).
-    def build(self, traces: Traces) -> ODs:
+    @classmethod
+    def build(cls, traces: Traces) -> ODs:
         ...
 
 

--- a/tests/arti/dummies.py
+++ b/tests/arti/dummies.py
@@ -57,15 +57,25 @@ class A4(Artifact):
 
 
 class P1(Producer):
-    def build(self, a1: A1) -> A2:
+    a1: A1
+
+    @staticmethod
+    def build(a1: A1) -> A2:
         return A2()
 
 
 class P2(Producer):
-    def build(self, a2: A2) -> tuple[A3, A4]:
+    a2: A2
+
+    @staticmethod
+    def build(a2: A2) -> tuple[A3, A4]:
         return A3(), A4()
 
 
 class P3(Producer):
-    def build(self, a1: A1, a2: A2) -> tuple[A3, A4]:
+    a1: A1
+    a2: A2
+
+    @staticmethod
+    def build(a1: A1, a2: A2) -> tuple[A3, A4]:
         return A3(), A4()


### PR DESCRIPTION
I think this lays most of the foundation for `pydantic` `Producers`. In order to build the appropriate model, a
`Producer` must now set the fields in the top level matching the `.build` signature.

I still need to:
- [x] Validate the `.build`/`.map` arguments are a subset of the model ones (`cls.__fields__`) and match on type
- [X] ~Validate no Optional/default None fields or add support for them~ We should support optional, but the Fingerprint logic mentioned below doesn't exist yet (so will keep in mind)
    - Do we need more entropy or "if dep is Optional and missing, replace Fingerprint.empty() with Fingerprint.identity()"?

In future PRs, I'll take a stab at:
- Support Annotated / View arguments to Producer.build
    - Check the root type can be loaded into a View
- `build` decorator -> Producer subclass (auto setup fields)
