### PR TITLE
Replace Type.metadata with TypeSystem hints

### DIFF
--- a/src/arti/internal/models.py
+++ b/src/arti/internal/models.py
@@ -131,10 +131,6 @@ class Model(BaseModel):
         validate_assignment = True  # Unused with frozen, unless that is overridden in subclass.
 
     @classmethod
-    def _pydantic_type_system_ignored_fields_hook_(cls) -> frozenset[str]:
-        return frozenset()
-
-    @classmethod
     def _pydantic_type_system_post_field_conversion_hook_(
         cls, type_: arti.types.Type, *, name: str, required: bool
     ) -> arti.types.Type:

--- a/src/arti/internal/utils.py
+++ b/src/arti/internal/utils.py
@@ -306,6 +306,3 @@ class TypedBox(Box, MutableMapping[str, Union[T, MutableMapping[str, T]]]):
             raise ValueError(f"{item} is already set!")
         else:
             super()._Box__convert_and_store(item, self.__cast_value(value))
-
-
-ObjectBox = TypedBox[object]

--- a/src/arti/types/pydantic.py
+++ b/src/arti/types/pydantic.py
@@ -11,12 +11,6 @@ from arti.types.python import python_type_system
 pydantic_type_system = TypeSystem(key="pydantic")
 
 
-def get_ignored_fields(type_: Any) -> frozenset[str]:
-    if hasattr(type_, "_pydantic_type_system_ignored_fields_hook_"):
-        return type_._pydantic_type_system_ignored_fields_hook_()  # type: ignore
-    return frozenset()
-
-
 class _PostFieldConversionHook(Protocol):
     def __call__(self, type_: Type, *, name: str, required: bool) -> Type:
         raise NotImplementedError()
@@ -34,8 +28,8 @@ class BaseModelAdapter(TypeAdapter):
     system = BaseModel
 
     @staticmethod
-    def _field_to_artigraph(field: ModelField) -> Type:
-        subtype = python_type_system.to_artigraph(field.outer_type_)
+    def _field_to_artigraph(field: ModelField, *, hints: dict[str, Any]) -> Type:
+        subtype = python_type_system.to_artigraph(field.outer_type_, hints=hints)
         return get_post_field_conversion_hook(subtype)(
             subtype,
             name=field.name,
@@ -45,27 +39,21 @@ class BaseModelAdapter(TypeAdapter):
         )
 
     @classmethod
-    def to_artigraph(cls, type_: type[BaseModel]) -> Type:
-        ignored_fields = get_ignored_fields(type_)
+    def to_artigraph(cls, type_: type[BaseModel], *, hints: dict[str, Any]) -> Type:
         return Struct(
             name=type_.__name__,
             fields={
-                field.name: cls._field_to_artigraph(field)
+                field.name: cls._field_to_artigraph(field, hints=hints)
                 for field in type_.__fields__.values()
-                if field.name not in ignored_fields
-            },
-            # TODO: Should we formalize "hints" with an enum passed to the TypeSystem?
-            metadata={
-                pydantic_type_system.key: {"is_model": True},
             },
         )
 
     @classmethod
-    def matches_system(cls, type_: Any) -> bool:
+    def matches_system(cls, type_: Any, *, hints: dict[str, Any]) -> bool:
         return lenient_issubclass(type_, cls.system)
 
     @classmethod
-    def to_system(cls, type_: Type) -> type[BaseModel]:
+    def to_system(cls, type_: Type, *, hints: dict[str, Any]) -> type[BaseModel]:
         assert isinstance(type_, Struct)
         return type(
             f"{type_.name}",
@@ -73,9 +61,9 @@ class BaseModelAdapter(TypeAdapter):
             {
                 "__annotations__": {
                     k: (
-                        pydantic_type_system.to_system(v)
+                        pydantic_type_system.to_system(v, hints=hints)
                         if isinstance(v, Struct)
-                        else python_type_system.to_system(v)
+                        else python_type_system.to_system(v, hints=hints)
                     )
                     for k, v in type_.fields.items()
                 }
@@ -93,20 +81,20 @@ class _PythonBaseModelAdapter(_ScalarClassTypeAdapter):
     priority = int(1e8)  # Beneath the Optional Adapter
 
     @classmethod
-    def matches_artigraph(cls, type_: Type) -> bool:
+    def matches_artigraph(cls, type_: Type, *, hints: dict[str, Any]) -> bool:
         # Avoid converting a python type to a BaseModel unless explicit annotated.
-        return super().matches_artigraph(type_) and type_.get_metadata(
+        return super().matches_artigraph(type_, hints=hints) and hints.get(
             f"{pydantic_type_system.key}.is_model", False
         )
 
     @classmethod
-    def to_artigraph(cls, type_: Any) -> Type:
-        return BaseModelAdapter.to_artigraph(type_)
+    def to_artigraph(cls, type_: Any, *, hints: dict[str, Any]) -> Type:
+        return BaseModelAdapter.to_artigraph(type_, hints=hints)
 
     @classmethod
-    def matches_system(cls, type_: Any) -> bool:
-        return BaseModelAdapter.matches_system(type_)
+    def matches_system(cls, type_: Any, *, hints: dict[str, Any]) -> bool:
+        return BaseModelAdapter.matches_system(type_, hints=hints)
 
     @classmethod
-    def to_system(cls, type_: Type) -> Any:
-        return BaseModelAdapter.to_system(type_)
+    def to_system(cls, type_: Type, *, hints: dict[str, Any]) -> Any:
+        return BaseModelAdapter.to_system(type_, hints=hints)

--- a/tests/arti/types/test_python_adapters.py
+++ b/tests/arti/types/test_python_adapters.py
@@ -28,41 +28,41 @@ from arti.types.python import PyLiteral, PyOptional, python_type_system
 
 
 def test_python_bool() -> None:
-    assert isinstance(python_type_system.to_artigraph(bool), Boolean)
-    assert python_type_system.to_system(Boolean()) is bool
+    assert isinstance(python_type_system.to_artigraph(bool, hints={}), Boolean)
+    assert python_type_system.to_system(Boolean(), hints={}) is bool
 
 
 def test_python_numerics() -> None:
-    assert isinstance(python_type_system.to_artigraph(int), Int64)
+    assert isinstance(python_type_system.to_artigraph(int, hints={}), Int64)
     for int_type in (Int64, Int32, Int16, Int8):
-        assert python_type_system.to_system(int_type()) is int
+        assert python_type_system.to_system(int_type(), hints={}) is int
 
-    assert isinstance(python_type_system.to_artigraph(float), Float64)
+    assert isinstance(python_type_system.to_artigraph(float, hints={}), Float64)
     for float_type in (Float64, Float32, Float16):
-        assert python_type_system.to_system(float_type()) is float
+        assert python_type_system.to_system(float_type(), hints={}) is float
 
 
 def test_python_str() -> None:
-    assert isinstance(python_type_system.to_artigraph(str), String)
-    assert python_type_system.to_system(String()) is str
+    assert isinstance(python_type_system.to_artigraph(str, hints={}), String)
+    assert python_type_system.to_system(String(), hints={}) is str
 
 
 def test_python_datetime() -> None:
-    assert isinstance(python_type_system.to_artigraph(datetime), Timestamp)
-    assert python_type_system.to_system(Timestamp(precision="microsecond")) is datetime
-    assert python_type_system.to_system(Timestamp(precision="millisecond")) is datetime
-    assert python_type_system.to_system(Timestamp(precision="second")) is datetime
+    assert isinstance(python_type_system.to_artigraph(datetime, hints={}), Timestamp)
+    assert python_type_system.to_system(Timestamp(precision="microsecond"), hints={}) is datetime
+    assert python_type_system.to_system(Timestamp(precision="millisecond"), hints={}) is datetime
+    assert python_type_system.to_system(Timestamp(precision="second"), hints={}) is datetime
 
-    assert isinstance(python_type_system.to_artigraph(date), Date)
-    assert python_type_system.to_system(Date()) is date
+    assert isinstance(python_type_system.to_artigraph(date, hints={}), Date)
+    assert python_type_system.to_system(Date(), hints={}) is date
 
 
 def test_python_list() -> None:
     a = List(value_type=Int64())
     p = list[int]
 
-    assert python_type_system.to_system(a) == p
-    assert python_type_system.to_artigraph(p) == a
+    assert python_type_system.to_system(a, hints={}) == p
+    assert python_type_system.to_artigraph(p, hints={}) == a
 
 
 def test_python_literal() -> None:
@@ -70,48 +70,48 @@ def test_python_literal() -> None:
     a = Enum(type=Int64(), items=(1, 2, 3))
     p = Literal[3, 2, 1]
 
-    assert python_type_system.to_system(a) == p
-    assert python_type_system.to_artigraph(p) == a
-    assert python_type_system.to_artigraph(Literal[1.0, 2.0]) == Enum(
+    assert python_type_system.to_system(a, hints={}) == p
+    assert python_type_system.to_artigraph(p, hints={}) == a
+    assert python_type_system.to_artigraph(Literal[1.0, 2.0], hints={}) == Enum(
         type=Float64(), items=(1.0, 2.0)
     )
     # Check for Union+Literal combos
-    assert python_type_system.to_artigraph(Union[Literal[1], Literal[2, 3]]) == a
+    assert python_type_system.to_artigraph(Union[Literal[1], Literal[2, 3]], hints={}) == a
     # Optional uses a Union as well, so add a few extra checks
     nullable_a = a.copy(update={"nullable": True})
-    assert python_type_system.to_artigraph(Optional[Literal[1, 2, 3]]) == nullable_a
-    assert python_type_system.to_artigraph(Union[Literal[1, 2, 3], None]) == nullable_a
+    assert python_type_system.to_artigraph(Optional[Literal[1, 2, 3]], hints={}) == nullable_a
+    assert python_type_system.to_artigraph(Union[Literal[1, 2, 3], None], hints={}) == nullable_a
 
 
 def test_python_literal_errors() -> None:
     with pytest.raises(ValueError, match="All Literals must be the same type"):
-        assert python_type_system.to_artigraph(Literal[1, 1.0])
+        assert python_type_system.to_artigraph(Literal[1, 1.0], hints={})
     with pytest.raises(NotImplementedError, match="Invalid Literal with no values"):
-        PyLiteral.to_artigraph(Literal[()])
+        PyLiteral.to_artigraph(Literal[()], hints={})
     # Confirm other Unions aren't handled
     for invalid_hint in (Union[int, str], Union[int, Literal[1]]):
         with pytest.raises(NotImplementedError, match="No TypeSystem.* adapter for system type"):
-            assert python_type_system.to_artigraph(invalid_hint)
+            assert python_type_system.to_artigraph(invalid_hint, hints={})
     # This path shouldn't normally be accessible (ie: `match_system` should guard against it, as
     # above), but are there for extra safety.
     with pytest.raises(
         NotImplementedError,
         match=re.escape("Only Union[Literal[...], ...] (enums) are currently supported"),
     ):
-        PyLiteral.to_artigraph(Union[int, str])
+        PyLiteral.to_artigraph(Union[int, str], hints={})
 
 
 def test_python_map() -> None:
     a = Map(key_type=String(), value_type=Int64())
     p = dict[str, int]
 
-    assert python_type_system.to_system(a) == p
-    assert python_type_system.to_artigraph(p) == a
+    assert python_type_system.to_system(a, hints={}) == p
+    assert python_type_system.to_artigraph(p, hints={}) == a
 
 
 def test_python_null() -> None:
-    assert isinstance(python_type_system.to_artigraph(NoneType), Null)
-    assert python_type_system.to_system(Null()) is NoneType
+    assert isinstance(python_type_system.to_artigraph(NoneType, hints={}), Null)
+    assert python_type_system.to_system(Null(), hints={}) is NoneType
 
 
 @pytest.mark.parametrize(
@@ -128,8 +128,8 @@ def test_python_optional(arti: Type, py: Any) -> None:
         # Confirm non-null too
         (arti.copy(update={"nullable": False}), get_args(py)[0]),
     ]:
-        assert python_type_system.to_system(a) == p
-        assert python_type_system.to_artigraph(p) == a
+        assert python_type_system.to_system(a, hints={}) == p
+        assert python_type_system.to_artigraph(p, hints={}) == a
 
 
 def test_python_optional_priority() -> None:
@@ -144,7 +144,7 @@ def test_python_struct() -> None:
         x: int
 
     # TypedDicts don't support equality (they must check on id or similar).
-    P1 = python_type_system.to_system(a)
+    P1 = python_type_system.to_system(a, hints={})
     assert P1.__name__ == P.__name__
     assert get_type_hints(P1) == {"x": int}
-    assert python_type_system.to_artigraph(P) == a
+    assert python_type_system.to_artigraph(P, hints={}) == a


### PR DESCRIPTION
Rather than storing arbitrary `Type.metadata` for use as "hints" during TypeSystem conversions, this formalizes a `hints` argument to the `to_artigraph` and `to_system` `TypeSystem`/`TypeAdapter` methods.

In the future, we may add some (optional) "supported hints" Enum validation (eg: `sgqlc_type_system` accepts "sgqlc.abstract" and "sgqlc.interfaces" hints).
