### PR TITLE
Use pre-commit in CI and remove pytest-black to fix pytest 7 compat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,12 @@ jobs:
         poetry install
     - name: code-checkers
       run: |
-        shopt -s nullglob # Ignore no glob matches below
-        poetry run bandit -ll -r src/
-        poetry run blacken-docs {**/,}*.{md,py}
-        poetry run pyupgrade --keep-runtime-typing --py39-plus {**/,}*.py
+        # Skip:
+        # - no-commit-to-branch since this will run on merged commits too
+        # - pytest so that we can run below with specific flags
+        SKIP=no-commit-to-branch,pytest poetry run pre-commit run -a
+        # We don't run trufflehod in pre-commit due to issues with new branches:
+        #   https://github.com/artigraph/artigraph/issues/188
         poetry run trufflehog --exclude_paths .trufflehog_ignore.txt --regex .
     - name: pytest
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         # - no-commit-to-branch since this will run on merged commits too
         # - pytest so that we can run below with specific flags
         SKIP=no-commit-to-branch,pytest poetry run pre-commit run -a
-        # We don't run trufflehod in pre-commit due to issues with new branches:
+        # We don't run trufflehog in pre-commit due to issues with new branches:
         #   https://github.com/artigraph/artigraph/issues/188
         poetry run trufflehog --exclude_paths .trufflehog_ignore.txt --regex .
     - name: pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -1260,19 +1260,6 @@ elasticsearch = ["elasticsearch"]
 histogram = ["pygal", "pygaljs"]
 
 [[package]]
-name = "pytest-black"
-version = "0.3.12"
-description = "A pytest plugin to enable format checking with black"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-black = {version = "*", markers = "python_version >= \"3.6\""}
-pytest = ">=3.5.0"
-toml = "*"
-
-[[package]]
 name = "pytest-cov"
 version = "3.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -1298,18 +1285,6 @@ python-versions = "*"
 [package.dependencies]
 flake8 = ">=3.5"
 pytest = ">=3.5"
-
-[[package]]
-name = "pytest-isort"
-version = "3.0.0"
-description = "py.test plugin to check import ordering using isort"
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4"
-
-[package.dependencies]
-isort = ">=4.0"
-pytest = ">=5.0"
 
 [[package]]
 name = "pytest-mypy"
@@ -1699,7 +1674,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9d3659e633ecdc787b1263a304e323a87cc9cf068c88f45f27ae1dd2125a5a1d"
+content-hash = "c3c4c79a86d9a3192edc7129b54b9074b879d2be3a5219e52ca557da1a8b031b"
 
 [metadata.files]
 aiohttp = [
@@ -2560,9 +2535,6 @@ pytest-benchmark = [
     {file = "pytest-benchmark-3.4.1.tar.gz", hash = "sha256:40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47"},
     {file = "pytest_benchmark-3.4.1-py2.py3-none-any.whl", hash = "sha256:36d2b08c4882f6f997fd3126a3d6dfd70f3249cde178ed8bbc0b73db7c20f809"},
 ]
-pytest-black = [
-    {file = "pytest-black-0.3.12.tar.gz", hash = "sha256:1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5"},
-]
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
@@ -2570,10 +2542,6 @@ pytest-cov = [
 pytest-flake8 = [
     {file = "pytest-flake8-1.1.0.tar.gz", hash = "sha256:358d449ca06b80dbadcb43506cd3e38685d273b4968ac825da871bd4cc436202"},
     {file = "pytest_flake8-1.1.0-py2.py3-none-any.whl", hash = "sha256:f1b19dad0b9f0aa651d391c9527ebc20ac1a0f847aa78581094c747462bfa182"},
-]
-pytest-isort = [
-    {file = "pytest-isort-3.0.0.tar.gz", hash = "sha256:4fe4b26ead2af776730ec23f5870d7421f35aace22a41c4e938586ef4d8787cb"},
-    {file = "pytest_isort-3.0.0-py3-none-any.whl", hash = "sha256:2d96a25a135d6fd084ac36878e7d54f26f27c6987c2c65f0d12809bffade9cb9"},
 ]
 pytest-mypy = [
     {file = "pytest-mypy-0.9.1.tar.gz", hash = "sha256:9ffa3bf405c12c5c6be9e92e22bebb6ab2c91b9c32f45b0f0c93af473269ab5c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,8 @@ pre-commit = "2.17.0"
 pylint = "^2.12.2"
 pytest = "6.2.5"
 pytest-benchmark = "3.4.1"
-pytest-black = "0.3.12"
 pytest-cov = "3.0.0"
 pytest-flake8 = "1.1.0"
-pytest-isort = "3.0.0"
 pytest-mypy = "0.9.1"
 pytest-sugar = "0.9.4"
 pyupgrade = "^2.31.1"
@@ -123,7 +121,7 @@ generated-members="sh"
 
 
 [tool.pytest.ini_options]
-addopts = "--black --cov --cov-report=term-missing --flake8 --isort --mypy --no-cov-on-fail "
+addopts = "--cov --cov-report=term-missing --flake8 --mypy --no-cov-on-fail "
 filterwarnings = [
     "error",
     # Filter flake8<->importlib-metadata deprecation

--- a/src/arti/artifacts/__init__.py
+++ b/src/arti/artifacts/__init__.py
@@ -24,6 +24,10 @@ class BaseArtifact(Model):
     - type: spec of the data's structure, such as data types, nullable, etc.
     - format: the data's serialized format, such as CSV, Parquet, database native, etc.
     - storage: the data's persistent storage system, such as blob storage, database native, etc.
+
+    ```python
+    x=5#junk
+    ```
     """
 
     # NOTE: Narrow the fields that affect the fingerprint to minimize changes (which trigger

--- a/src/arti/artifacts/__init__.py
+++ b/src/arti/artifacts/__init__.py
@@ -24,10 +24,6 @@ class BaseArtifact(Model):
     - type: spec of the data's structure, such as data types, nullable, etc.
     - format: the data's serialized format, such as CSV, Parquet, database native, etc.
     - storage: the data's persistent storage system, such as blob storage, database native, etc.
-
-    ```python
-    x=5#junk
-    ```
     """
 
     # NOTE: Narrow the fields that affect the fingerprint to minimize changes (which trigger


### PR DESCRIPTION
- Remove pytest-isort/pytest-black to work around pytest 7 compatibility; use pre-commit in CI
- Test pre-commit blacken-docs
- Remove test doc

# Description

`pytest` 7 [breaks](https://github.com/artigraph/artigraph/pull/197) `pytest-black`. We already call black during `pre-commit` and have some duplicate logic in CI, so I just removed the `pytest-black` and `pytest-isort` deps and standardize on `pre-commit`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Chanced CI, committed a bad doc to test `blacken-docs` via `pre-commit` in CI, and then removed that.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in upstream modules
