### PR TITLE
Attempt to fix skipped CI jobs on external PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+    - golden
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  pull_request:
   push:
   workflow_dispatch:
 


### PR DESCRIPTION
# Description

CI hasn't run on the last couple external PRs ([1](https://github.com/artigraph/artigraph/pull/234), [2](https://github.com/artigraph/artigraph/pull/250)). I think this is because the trigger is for `push`, but pushes against a fork don't count(?). This adds the `pull_request` trigger, which will hopefully prompt the ["workflow approval" flow](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks).
