### PR TITLE
Move arti.internal.version to arti.__version__

### DIFF
--- a/src/arti/__init__.py
+++ b/src/arti/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib.metadata
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+__version__ = importlib.metadata.version("arti")
 
 import threading
 from typing import Optional

--- a/src/arti/internal/__init__.py
+++ b/src/arti/internal/__init__.py
@@ -1,8 +1,5 @@
-import importlib.metadata
 from collections.abc import Iterator
 from contextlib import contextmanager
-
-version = importlib.metadata.version("arti")
 
 
 @contextmanager

--- a/tests/arti/internal/test_internal.py
+++ b/tests/arti/internal/test_internal.py
@@ -1,10 +1,6 @@
 import pytest
 
-from arti.internal import version, wrap_exc
-
-
-def test_version() -> None:
-    assert version is not None
+from arti.internal import wrap_exc
 
 
 def test_wrap_exc() -> None:

--- a/tests/arti/test_version.py
+++ b/tests/arti/test_version.py
@@ -1,0 +1,5 @@
+from arti import __version__
+
+
+def test_version() -> None:
+    assert __version__ is not None


### PR DESCRIPTION
# Description

Once upon a time, I didn't know how to handle extending namespace packages with an `__init__.py` module (maybe I'm deluding myself that I do now :grin:), so [moved `arti.__version__` to `arti.internal.version`](https://github.com/artigraph/artigraph/commit/2e70d58baf26f6cd7b87629c57c64aecf1ce6b44). That has since been "fixed" with `__path__ = __import__("pkgutil").extend_path(__path__, __name__)` in the namespace `__init__.py`s, so we can move the version back for greater visibility.


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
