### PR TITLE
Fix pickling of Artifact.from_type(...) classes

### DIFF
--- a/tests/arti/artifacts/test_artifact.py
+++ b/tests/arti/artifacts/test_artifact.py
@@ -1,4 +1,5 @@
 import json
+import pickle
 import re
 from datetime import date, datetime
 from typing import Any
@@ -196,3 +197,9 @@ def test_Artifact_storage_path_resolution() -> None:
         storage: S
 
     assert A(storage=S()).storage.key == "test-a_key={a.key}"
+
+
+def test_Artifact_from_type_pickle() -> None:
+    artifact = Artifact.from_type(Int64())()
+    msg = pickle.dumps(artifact)
+    assert pickle.loads(msg) == artifact


### PR DESCRIPTION
# Description

Pickling of instances from `Artifact.from_type(...)` classes fails because the class name is not actually available in `arti.artifacts`. This fixes that by using a `_DynamicArtifact` intermediate class with a custom `__reduce__` implementation that triggers the dynamic class to be regenerated and then an object instantiated.

While we could simply add the generated types to `globals()` after generation, that wouldn't handle:
- loading a pickled representation from a separate session if that specific dynamic class hadn't already been generated in this session
- classes with duplicate names (they're currently named based on the `Type.__name__`, but there might be multiple, different _instance_ of the same type)

I think there are some larger changes we can make to `Artifact`/`Producer` that will remove the need for these dynamic classes (and thus these hacks), but this will suffice for now.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tests have been added for simple `pickle.{dumps,loads}` in the same session, but I tested reloading a pickle file across sessions by hand (this is harder to reliably test for).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
