### PR TITLE
Refactor Producer to leverage Type directly and allow direct Artifact instantiation

### DIFF
--- a/src/arti/executors/local.py
+++ b/src/arti/executors/local.py
@@ -40,7 +40,7 @@ class LocalExecutor(Executor):
             **{
                 name: partitions
                 for name, partitions in input_partitions.items()
-                if name in producer._map_input_metadata_
+                if name in producer._map_inputs_
             }
         )
         # TODO: Need to validate the partition_dependencies against the Producer's
@@ -87,12 +87,12 @@ class LocalExecutor(Executor):
                 name: graph.read(
                     artifact=producer.inputs[name],
                     storage_partitions=partition_dependencies[output_partition_key][name],
-                    view=view,
+                    view=ioinfo.view,
                 )
-                for name, view in producer._build_input_views_.items()
+                for name, ioinfo in producer._build_inputs_.items()
             }
             outputs = producer.build(**arguments)
-            if len(producer._output_metadata_) == 1:
+            if len(producer._outputs_) == 1:
                 outputs = (outputs,)
             validation_passed, validation_message = producer.validate_outputs(*outputs)
             if not validation_passed:
@@ -103,7 +103,7 @@ class LocalExecutor(Executor):
                     artifact=output_artifacts[i],
                     input_fingerprint=partition_input_fingerprints[output_partition_key],
                     keys=output_partition_key,
-                    view=producer._output_metadata_[i][1],
+                    view=producer._outputs_[i].view,
                 )
 
     def build(self, graph: Graph) -> None:

--- a/src/arti/internal/models.py
+++ b/src/arti/internal/models.py
@@ -227,3 +227,7 @@ class Model(BaseModel):
         cls, type_: "Type", *, name: str, required: bool
     ) -> "Type":
         return type_
+
+
+def get_field_default(model: type[Model], field: str) -> Optional[Any]:
+    return model.__fields__[field].default

--- a/tests/arti/artifacts/test_artifact.py
+++ b/tests/arti/artifacts/test_artifact.py
@@ -1,4 +1,5 @@
 import json
+import pickle
 import re
 from datetime import date, datetime
 from typing import Any
@@ -161,3 +162,9 @@ def test_Artifact_storage_path_resolution() -> None:
         storage: S
 
     assert A(storage=S()).storage.key == "test-a_key={a.key}"
+
+
+def test_Artifact_pickle() -> None:
+    artifact = Artifact.cast(10)
+    msg = pickle.dumps(artifact)
+    assert pickle.loads(msg) == artifact

--- a/tests/arti/dummies.py
+++ b/tests/arti/dummies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Sequence
+from typing import Annotated, Any
 
 from arti import (
     Annotation,
@@ -15,6 +16,8 @@ from arti import (
     StoragePartition,
     Type,
     TypeSystem,
+    View,
+    io,
     producer,
 )
 from arti.formats.json import JSON
@@ -62,6 +65,27 @@ class DummyStorage(Storage[DummyPartition]):
         if input_fingerprints is not None and input_fingerprints != InputFingerprints():
             raise NotImplementedError()
         return (self.generate_partition(),)
+
+
+@io.register_reader
+def dummy_reader(
+    type_: Type,
+    format: DummyFormat,
+    storage_partitions: Sequence[DummyPartition],
+    view: View,
+) -> Any:
+    return "test-read"
+
+
+@io.register_writer
+def dummy_writer(
+    data: object,
+    type_: Type,
+    format: DummyFormat,
+    storage_partition: DummyPartition,
+    view: View,
+) -> None:
+    pass
 
 
 class DummyStatistic(Statistic):

--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -8,6 +8,7 @@ from box import BoxError
 from arti import Artifact, CompositeKey, Fingerprint, Graph, producer
 from arti.backends.memory import MemoryBackend
 from arti.executors.local import LocalExecutor
+from arti.formats.json import JSON
 from arti.internal.utils import frozendict
 from arti.storage.literal import StringLiteral
 from arti.storage.local import LocalFile, LocalFilePartition
@@ -63,12 +64,15 @@ def test_Graph_literals(tmp_path: Path) -> None:
         # snapshot_id.
         g.artifacts.phase = Num(storage=LocalFile(path=str(tmp_path / "phase.json")))
 
-    Int64Artifact = Artifact.from_type(Int64())
     x, y, z, phase = g.artifacts.x, g.artifacts.y, g.artifacts.z, g.artifacts.phase
-    assert isinstance(x, Int64Artifact)
+    assert isinstance(x, Artifact)
+    assert isinstance(x.type, Int64)
+    assert isinstance(x.format, JSON)
     assert isinstance(x.storage, StringLiteral)
     assert x.storage.value == "1"
-    assert isinstance(z, Int64Artifact)
+    assert isinstance(z, Artifact)
+    assert isinstance(z.type, Int64)
+    assert isinstance(z.format, JSON)
     assert isinstance(z.storage, StringLiteral)
     assert z.storage.value is None
 


### PR DESCRIPTION
# Description

This refactors `Producer` to operate primarily against a `Type` rather than requiring a strict `Artifact` subclass (with a nested `Type`). The `Type` is derived from the parameter type annotations, by one of the following mechanisms:
- inferring from the type hint (via `python_type_system`) (`int`)
- using a `Type` instance embedded in an `Annotated` type hint (`Annotated[int, Int64()]`)
- using a `Artifact` class with a `type` default set embedded in an `Annotated` type hint (`Annotated[int, MyArtifact]`)

Relaxing the requirement for `Artifact` subclass improves simple cases of `Producer` and `Graph` creation significantly and allows direct `Artifact` instantiation. As requested in #260, this simple example now works as expected:
```python
from arti import Graph, producer

@producer()
def increment(numbers: list[int], by: int) -> list[int]:
    return [n + by for n in numbers]

with Graph(name="Demo") as g:
    g.artifacts.step, g.artifacts.numbers = 5, [1, 2, 3]
    g.artifacts.incremented = increment(numbers=g.artifacts.numbers, by=g.artifacts.step)

if __name__ == "__main__":
    g.build()
    print(g.read(g.artifacts.numbers, annotation=list[int]))
    print(g.read(g.artifacts.incremented, annotation=list[int]))
```
, yielding:
```
[1, 2, 3]
[6, 7, 8]
```

Resolves #260 and supersedes #259 (pickling now works fine w/o the dynamic classes).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tests have been updated and added to maintain coverage.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules