### PR TITLE
Support Graph pickling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2328,38 +2328,48 @@ termcolor = ">=1.1.0"
 
 [[package]]
 name = "python-box"
-version = "6.1.0"
+version = "7.0.0"
 description = "Advanced Python dictionaries with dot notation access"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "python-box-6.1.0.tar.gz", hash = "sha256:6e7c243b356cb36e2c0f0e5ed7850969fede6aa812a7f501de7768996c7744d7"},
-    {file = "python_box-6.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:c14aa4e72bf30f4d573e62ff8030a86548603a100c3fb534561dbedf4a83f454"},
-    {file = "python_box-6.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab13208b053525ef154a36a4a52873b98a12b18b946edd4c939a4d5080e9a218"},
-    {file = "python_box-6.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:d199cd289b4f4d053770eadd70217c76214aac30b92a23adfb9627fd8558d300"},
-    {file = "python_box-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac44b3b85714a4575cc273b5dbd39ef739f938ef6c522d6757704a29e7797d16"},
-    {file = "python_box-6.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f0036f91e13958d2b37d2bc74c1197aa36ffd66755342eb64910f63d8a2990f"},
-    {file = "python_box-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:af6bcee7e1abe9251e9a41ca9ab677e1f679f6059321cfbae7e78a3831e0b736"},
-    {file = "python_box-6.1.0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:11cbe62f0dace8a6e2a10d210a5e87b99ad1a1286865568862516794c923a988"},
-    {file = "python_box-6.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa4696b5e09ccf695bf05c16bb5ca1fcc95a141a71a31eb262eee8e2ac07189a"},
-    {file = "python_box-6.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3638d3559f19ece7fa29f6a6550bc64696cd3b65e3d4154df07a3d06982252ff"},
-    {file = "python_box-6.1.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:53998c3b95e31d1f31e46279ef1d27ac30b137746927260901ee61457f8468a0"},
-    {file = "python_box-6.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:594b0363b187df855ff8649488b1301dddbbeea769629b7caeb584efe779b841"},
-    {file = "python_box-6.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:1d29eafaa287857751e27fbe9a08dd856480f0037fe988b221eba4dac33e5852"},
-    {file = "python_box-6.1.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:9dbd92b67c443a97326273c9239fce04d3b6958be815d293f96ab65bc4a9dae7"},
-    {file = "python_box-6.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed6d7fe47d756dc2d9dea448702cea103716580a2efee7c859954929295fe28e"},
-    {file = "python_box-6.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7b73f26e40a7adc57b9e39f5687d026dfa8a336f48aefaf852a223b4e37392ad"},
-    {file = "python_box-6.1.0-py3-none-any.whl", hash = "sha256:bdec0a5f5a17b01fc538d292602a077aa8c641fb121e1900dff0591791af80e8"},
+    {file = "python_box-7.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fea273a8e40bcaf535a7f1253457e77f940cc2c059766a13769de4d68ccbcf16"},
+    {file = "python_box-7.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0c3716334228b939d49d5e1f0e1f2619dbe8a72a9d7c82f19fab41c53f407f7"},
+    {file = "python_box-7.0.0-cp310-cp310-manylinux_2_35_x86_64.whl", hash = "sha256:ace7ddd55590c78aacf7b287fc6d346220e46093d10b7acffdb4b66a9ed8ea5c"},
+    {file = "python_box-7.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e82a6ebb2d049ba8bd475d64290d5334a1fb2b49fc54ee34809a115b7042aac2"},
+    {file = "python_box-7.0.0-cp310-cp310-win32.whl", hash = "sha256:194d1106fdcfde9bbd47cd1cf2a3c743e6b75f8f66c200b7353fa0e51596bbaa"},
+    {file = "python_box-7.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:973059f5b72c73feaaff5f3b5a10a34f138d11f197bfa8ef27b4e597ed13f259"},
+    {file = "python_box-7.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:87e0ad81bf934ec832df9e51f9880bb3e9b0cd99fe49d5bff9516bbf8108368c"},
+    {file = "python_box-7.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a25afebde5ab15f3b7e1eb33b63a98b9ebae24d12a1bc2f34862d4fa36a4ea2"},
+    {file = "python_box-7.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ee9a38381c13d886945fda7e332307454aeb4db1478f6a2ce9ed6a45cdc002d0"},
+    {file = "python_box-7.0.0-cp311-cp311-win32.whl", hash = "sha256:9330cf1ffd3631e1a40867847cb4ca4b746f1effea7b052c3a8c0046dbae86a1"},
+    {file = "python_box-7.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:c05a12aac622a07b8a84be6c5171e24fe2a2e58e1c7870439fa3696a407caa8d"},
+    {file = "python_box-7.0.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:78a060b2d2af9a40f0bffce5b588f92fa86e07a68f0f2fa588fdf79e36971cf6"},
+    {file = "python_box-7.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:011875da351e884658e41f04191df3ba7b7fa74a43506988b03168fb6b597d39"},
+    {file = "python_box-7.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bb8b9d00ef3fd5110276202dcfa60d719609c1c98f24a7dd6a1b19676fd512dd"},
+    {file = "python_box-7.0.0-cp37-cp37m-win32.whl", hash = "sha256:ed0948c06f1b5a3d959cb79ee6825f509a6979d5599ca7a786fe856e9515fa31"},
+    {file = "python_box-7.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:25b93b8710add337c2330e8aa03fec3b06db742a858e2b5c8f3de1c48ac57507"},
+    {file = "python_box-7.0.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:bc91dfb5672a6d4e0c7ca2672990bc84096a31a15d6449b9a58fb2f05b196a20"},
+    {file = "python_box-7.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c78ae2652566b1ea3095ea581c1c305016aa9a1d7705e4ab84db7d68ab43c5ca"},
+    {file = "python_box-7.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8e30a32226da7c4a23919d92fc6d4d4b9bc36e77e0702ecdcd1802e422dabc5d"},
+    {file = "python_box-7.0.0-cp38-cp38-win32.whl", hash = "sha256:4c006d2284b7eef0ce9b7eea829bf3efb52ab7b3584df9170c444b3030624057"},
+    {file = "python_box-7.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:ee15b02b5d8c034553dd6dcaa0b1f0e56a49ca9f5d95a7c5883e83c00b8bd05c"},
+    {file = "python_box-7.0.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:ec34c6577934b9fe8be82047671b4561f3589cff45b036792797941220317ced"},
+    {file = "python_box-7.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352f29a4fe26f7a77ead771682670740a112ddc14aa6ccf4550a2f8651c1b6b2"},
+    {file = "python_box-7.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e76e5b6797851ed6863585f2fdc6d472c4ec3d68886e966acd33da212d5030f5"},
+    {file = "python_box-7.0.0-cp39-cp39-win32.whl", hash = "sha256:ae5cb0f58ea299f3ac6b2ef065eaf4cd6192a2f7d3a7a560aa6012777271a724"},
+    {file = "python_box-7.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:a681b16b7c6b437340cf1df1834e2a7f835c07a7189371563dd7ac70510a6c09"},
+    {file = "python_box-7.0.0.tar.gz", hash = "sha256:727af276177b3c2c0e7e2acea2152269ec85d9fc012a4ffe8df962e2a2d57613"},
 ]
 
 [package.extras]
-all = ["msgpack", "ruamel.yaml (>=0.17)", "toml"]
-msgpack = ["msgpack"]
-pyyaml = ["PyYAML"]
+all = ["msgpack (>=1.0.0)", "ruamel.yaml (>=0.17)", "tomli (>=1.2.3)", "tomli-w (>=1.0.0)"]
+msgpack = ["msgpack (>=1.0.0)"]
+pyyaml = ["PyYAML (>=6.0)"]
 ruamel-yaml = ["ruamel.yaml (>=0.17)"]
-toml = ["toml"]
-tomli = ["tomli", "tomli-w"]
+toml = ["toml (>=0.10.2)"]
+tomli = ["tomli (>=1.2.3)", "tomli-w (>=1.0.0)"]
 yaml = ["ruamel.yaml (>=0.17)"]
 
 [[package]]
@@ -3072,4 +3082,4 @@ all = ["gcsfs", "numpy", "pandas", "pyarrow"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "675c27444a5d2a9b751edc6411c248244aa106b8218e8b5611a9fb01f70e2d4a"
+content-hash = "acfcd0937f2881b46673965b3dcb22d5e3f5f8d2305dd36e787cdf7a6c0bcb30"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ parse = ">=1.19.0"
 pyarrow = {version = ">=8", optional = true}
 pydantic = ">=1.9.0,<2"  # We use some pydantic internals, so expect 2.0 to break things.
 pyfarmhash = ">=0.2.2"
-python-box = ">=5.4.1"
+python-box = ">=7.0.0" # Tracking box_namespace requires 7+
 
 python = "^3.9"
 

--- a/src/arti/backends/memory.py
+++ b/src/arti/backends/memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterator
 from contextlib import contextmanager
+from functools import partial
 
 from pydantic import PrivateAttr
 
@@ -39,7 +40,7 @@ class _NoCopyContainer(NoCopyMixin):
         # `container.storage_partitions` tracks all partitions, across all graphs. This separation is important
         # to allow for Literals to be used even after a snapshot_id change.
         self.graph_snapshot_partitions: _GraphSnapshotPartitions = defaultdict(
-            lambda: defaultdict(lambda: defaultdict(set[StoragePartition]))
+            partial(defaultdict, partial(defaultdict, set[StoragePartition]))  # type: ignore[arg-type]
         )
         self.graph_tags: dict[str, dict[str, Fingerprint]] = defaultdict(dict)
         self.storage_partitions: _StoragePartitions = defaultdict(set[StoragePartition])

--- a/src/arti/graphs/__init__.py
+++ b/src/arti/graphs/__init__.py
@@ -58,10 +58,6 @@ def requires_sealed(fn: Callable[..., _Return]) -> Callable[..., _Return]:
 
 
 class ArtifactBox(TypedBox[Artifact]):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        object.__setattr__(self, "_path", ())
-        super().__init__(*args, **kwargs)
-
     def _TypedBox__cast_value(self, item: str, artifact: Any) -> Artifact:
         artifact = super()._TypedBox__cast_value(item, artifact)  # type: ignore[misc]
         storage_template_values = dict[str, Any]()
@@ -69,7 +65,7 @@ class ArtifactBox(TypedBox[Artifact]):
             storage_template_values.update(
                 {
                     "graph_name": graph.name,
-                    "names": (*self._path, item),
+                    "names": (*self._box_config["box_namespace"], item),
                     "path_tags": graph.path_tags,
                 }
             )
@@ -92,19 +88,6 @@ class ArtifactBox(TypedBox[Artifact]):
                 update={"storage": artifact.storage.resolve_templates(**storage_template_values)}
             ),
         )
-
-    def _Box__convert_and_store(self, item: str, value: Artifact) -> None:
-        super()._Box__convert_and_store(item, value)  # pylint: disable=no-member
-        if isinstance(value, dict):
-            # TODO: Test if this works with `Box({"some": {"nested": "thing"}})`.
-            # Guessing not, may need to put in an empty dict/box first, set the path,
-            # and then update it.
-            object.__setattr__(self[item], "_path", self._path + (item,))
-
-    def _Box__get_default(self, item: str, attr: bool = False) -> Any:
-        value = super()._Box__get_default(item, attr=attr)  # type: ignore[misc]
-        object.__setattr__(value, "_path", self._path + (item,))
-        return value
 
 
 Node = Union[Artifact, Producer]

--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -1,3 +1,4 @@
+import pickle
 import re
 from pathlib import Path
 from typing import Annotated, cast
@@ -405,3 +406,12 @@ def test_Graph_storage_resolution() -> None:
     assert g.artifacts.root.a.storage.path.endswith("/test/tag=value/root/a/a.json")
     assert g.artifacts.root.b.storage.path.endswith("/test/tag=value/root/b/b.json")
     assert g.artifacts.c.storage.path.endswith("/test/tag=value/c/{input_fingerprint}/c.json")
+
+
+def test_ArtifactBox() -> None:
+    with Graph(name="test") as g:
+        g.artifacts.a.b.c = 5  # test chained assignment
+        g.artifacts.x = {"y": {"z": 5}}  # test direct nested assignment
+    assert g.artifacts.a.b.c.storage.id == "test/a/b/c/c.json"  # type: ignore[attr-defined]
+    assert g.artifacts.x.y.z.storage.id == "test/x/y/z/z.json"  # type: ignore[attr-defined]
+    assert g.artifacts == pickle.loads(pickle.dumps(g.artifacts))

--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -45,6 +45,10 @@ def test_Graph(graph: Graph) -> None:
     assert graph.artifacts.c.b.storage.includes_input_fingerprint_template
 
 
+def test_Graph_pickle(graph: Graph) -> None:
+    assert graph == pickle.loads(pickle.dumps(graph))
+
+
 def test_Graph_literals(tmp_path: Path) -> None:
     n_add_runs = 0
 


### PR DESCRIPTION
# Description

This fixes pickling a `Graph` object, which was blocked by issues pickling:
- `ArtifactBox` - the way we were tracking the nested names was messy and broken when pickling; we can now simplify with [some changes upstream to `box`](https://github.com/cdgriffith/Box/issues/226) (pending v7)
- `MemoryBackend` - an internal `defaultdict` referenced an inline `lambda`, which can't be pickled (why isn't `cloudpickle` the builtin :disappointed:)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
