### PR TITLE
Remove typing.Self use to fix py <3.11

### DIFF
--- a/src/arti/internal/utils.py
+++ b/src/arti/internal/utils.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Mu
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from types import GenericAlias, ModuleType
-from typing import IO, Any, ClassVar, Optional, Self, SupportsIndex, TypeVar, Union, cast
+from typing import IO, Any, ClassVar, Optional, SupportsIndex, TypeVar, Union, cast
 
 from box import Box
 
@@ -298,6 +298,9 @@ def qname(val: Union[object, type]) -> str:
     return type(val).__qualname__
 
 
+_Self = TypeVar("_Self")
+
+
 class NoCopyMixin:
     """Mixin to bypass (deep)copying.
 
@@ -305,10 +308,10 @@ class NoCopyMixin:
     preferring immutable data structures and Pydantic models, which (deep)copy often.
     """
 
-    def __copy__(self) -> Self:
+    def __copy__(self: _Self) -> _Self:
         return self  # pragma: no cover
 
-    def __deepcopy__(self, memo: Any) -> Self:
+    def __deepcopy__(self: _Self, memo: Any) -> _Self:
         return self  # pragma: no cover
 
 


### PR DESCRIPTION
# Description

Fix py 3.9 and 3.10 support.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
