### PR TITLE
Add explicit codecov/codecov-action token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,3 +54,4 @@ jobs:
         env_vars: OS,PYTHON_VERSION
         fail_ci_if_error: true
         files: coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  pull_request:
+  pull_request_target: # Using pull_request_target grants PRs from forks access to the codecov upload token secret, avoiding rate limits.
   push:
     branches:
     - golden

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,4 +54,4 @@ jobs:
         env_vars: OS,PYTHON_VERSION
         fail_ci_if_error: true
         files: coverage-${{ matrix.os }}-${{ matrix.python-version }}.xml
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ vars.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  pull_request_target: # Using pull_request_target grants PRs from forks access to the codecov upload token secret, avoiding rate limits.
+  pull_request:
   push:
     branches:
     - golden


### PR DESCRIPTION
# Description

The codecov action has [rate limiting issues](https://github.com/codecov/codecov-action/issues/837) (example failing workflow [here](https://github.com/artigraph/artigraph/actions/runs/4428851357/attempts/1)), so we'll go ahead and set the token explicitly. ~In order to still support PRs from forks to access the token (without just hard coding it in the config), this also changes to use the `pull_request_target` event.~ Setting `pull_request_target` up [right](https://github.com/artigraph/artigraph/pull/335#issuecomment-1470804526) is too much work for now, so just using a var for the token (accepting the risk of malicious coverage...).