### PR TITLE
Allow g.read with raw Artifacts even if others are missing

### DIFF
--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -80,6 +80,10 @@ def test_Graph_literals(tmp_path: Path) -> None:
     assert isinstance(z.storage, StringLiteral)
     assert z.storage.value is None
 
+    # Ensure we can read raw Artifacts, even if others are not populated yet.
+    assert g.read(x, annotation=int) == 1
+    with pytest.raises(FileNotFoundError, match="No data"):
+        assert g.read(y, annotation=int) == 1
     g.write(1, artifact=y)
     g.write(1, artifact=phase)
     with pytest.raises(FileNotFoundError, match="No data"):


### PR DESCRIPTION
# Description

`Graph.read` without any storage partitions passed in (as is common with interactive use) triggers a snapshot. However, if any of the raw Artifacts are missing, snapshotting will fail. This correctly blocks reading generated Artifacts, but we should still be able to read other raw Artifacts that do exist.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Extended a test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
