### PR TITLE
Use None instead of NoneType when matching annotations

### DIFF
--- a/src/arti/internal/dispatch.py
+++ b/src/arti/internal/dispatch.py
@@ -34,7 +34,7 @@ class _multipledispatch(_multimethod.multidispatch[RETURN]):
             self.discovery_func()
         return super().__missing__(types)
 
-    def lookup(self, *args: type[Any]) -> Callable[..., Any]:
+    def lookup(self, *args: Optional[type[Any]]) -> Callable[..., Any]:
         # multimethod wraps Generics (eg: `list[int]`) with an internal helper. We must do the same
         # before looking up. Non-Generics pass through as is.
         args = tuple(_multimethod.subtype(arg) for arg in args)  # type: ignore[no-untyped-call]

--- a/src/arti/internal/type_hints.py
+++ b/src/arti/internal/type_hints.py
@@ -43,6 +43,8 @@ def _check_issubclass(klass: Any, check_type: type) -> bool:
         return check_type is Any
     if check_type is Any:
         return True
+    if check_type is None:
+        return klass is NoneType
     # eg: issubclass(tuple, tuple)
     if klass_origin is None and check_type_origin is None:
         return issubclass(klass, check_type)
@@ -130,7 +132,9 @@ def get_item_from_annotated(
 
 
 def get_annotation_from_value(value: Any) -> Any:
-    if isinstance(value, (NoneType, bool, bytes, date, datetime, float, int, str)):
+    if value is None:
+        return None
+    if isinstance(value, (bool, bytes, date, datetime, float, int, str)):
         return type(value)
     if isinstance(value, (tuple, list, set, frozenset)):
         first, *tail = tuple(value)

--- a/src/arti/types/python.py
+++ b/src/arti/types/python.py
@@ -21,7 +21,6 @@ _generate(artigraph=arti.types.Binary, system=bytes)
 # NOTE: issubclass(bool, int) is True, so set higher priority
 _generate(artigraph=arti.types.Boolean, system=bool, priority=int(1e9))
 _generate(artigraph=arti.types.Date, system=datetime.date)
-_generate(artigraph=arti.types.Null, system=NoneType)
 _generate(artigraph=arti.types.String, system=str)
 for _precision in (16, 32, 64):
     _generate(
@@ -35,6 +34,18 @@ for _precision in (8, 16, 32, 64):
         system=int,
         priority=_precision,
     )
+
+
+@python_type_system.register_adapter
+class PyNone(_ScalarClassTypeAdapter):
+    # Python represents None types in type hints with the `None` value (not `NoneType`).
+
+    artigraph = arti.types.Null
+    system = None
+
+    @classmethod
+    def matches_system(cls, type_: Any, *, hints: dict[str, Any]) -> bool:
+        return type_ is None
 
 
 @python_type_system.register_adapter

--- a/src/arti/views/__init__.py
+++ b/src/arti/views/__init__.py
@@ -21,10 +21,10 @@ class View(Model):
     """
 
     _abstract_ = True
-    _by_python_type_: "ClassVar[dict[type, type[View]]]" = {}
+    _by_python_type_: "ClassVar[dict[Optional[type], type[View]]]" = {}
 
     priority: ClassVar[int] = 0  # Set priority of this view for its python_type. Higher is better.
-    python_type: ClassVar[type]
+    python_type: ClassVar[Optional[type]]
     type_system: ClassVar[TypeSystem]
 
     mode: MODE

--- a/src/arti/views/python.py
+++ b/src/arti/views/python.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime
 
-from arti.internal.type_hints import NoneType
 from arti.types.python import python_type_system
 from arti.views import View
 
@@ -36,7 +35,7 @@ class List(PythonBuiltin):
 
 
 class Null(PythonBuiltin):
-    python_type = NoneType
+    python_type = None
 
 
 class Str(PythonBuiltin):

--- a/tests/arti/types/test_python_adapters.py
+++ b/tests/arti/types/test_python_adapters.py
@@ -5,7 +5,6 @@ from typing import Any, Literal, Optional, TypedDict, Union, get_args, get_type_
 import pytest
 
 from arti import Type
-from arti.internal.type_hints import NoneType
 from arti.types import (
     Boolean,
     Collection,
@@ -122,8 +121,8 @@ def test_python_map() -> None:
 
 
 def test_python_null() -> None:
-    assert isinstance(python_type_system.to_artigraph(NoneType, hints={}), Null)
-    assert python_type_system.to_system(Null(), hints={}) is NoneType
+    assert isinstance(python_type_system.to_artigraph(None, hints={}), Null)
+    assert python_type_system.to_system(Null(), hints={}) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/arti/views/test_python.py
+++ b/tests/arti/views/test_python.py
@@ -3,7 +3,6 @@ from datetime import date, datetime
 
 from arti import Artifact, View, read, write
 from arti.formats.pickle import Pickle
-from arti.internal.type_hints import NoneType
 from arti.internal.utils import named_temporary_file
 from arti.storage.local import LocalFilePartition
 from arti.views.python import Date, Datetime, Dict, Float, Int, Null, Str
@@ -11,13 +10,13 @@ from arti.views.python import Date, Datetime, Dict, Float, Int, Null, Str
 
 def test_python_View() -> None:
     for val, view_class, python_type in [
+        ("", Str, str),
+        (1, Int, int),
+        (1.0, Float, float),
+        (None, Null, None),
         (date(1970, 1, 1), Date, date),
         (datetime(1970, 1, 1, 0), Datetime, datetime),
-        (dict(a=1), Dict, dict[str, int]),
-        (1.0, Float, float),
-        (1, Int, int),
-        (None, Null, NoneType),
-        ("", Str, str),
+        ({"a": 1}, Dict, dict[str, int]),
     ]:
         view = View.from_annotation(python_type, mode="READWRITE")
         assert isinstance(view, view_class)

--- a/tests/arti/views/test_views.py
+++ b/tests/arti/views/test_views.py
@@ -1,4 +1,4 @@
-from typing import Annotated, ClassVar
+from typing import Annotated, ClassVar, Optional
 
 import pytest
 from pydantic import ValidationError
@@ -11,7 +11,7 @@ from arti.types.python import python_type_system
 def MockView() -> type[View]:
     class V(View):
         _abstract_ = True
-        _by_python_type_: ClassVar[dict[type, type[View]]] = {}
+        _by_python_type_: ClassVar[dict[Optional[type], type[View]]] = {}
 
         # NOTE: The type hint is needed to fix https://github.com/pydantic/pydantic/issues/1777#issuecomment-1465026331
         type_system: ClassVar[TypeSystem] = python_type_system


### PR DESCRIPTION
# Description

Python normally represents `None` in type hints with the `None` value, not `NoneType`. However, the `python_type_system` would check for `isinstance(annotation, NoneType)` when matching, which caused some oddness when trying to validate a `None` value passed to a model. Instead, we now match on `None` directly.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Updated tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
