### PR TITLE
Persist Graph{Snapshot} in Backend

### DIFF
--- a/src/arti/executors/__init__.py
+++ b/src/arti/executors/__init__.py
@@ -26,8 +26,8 @@ class Executor(Model):
     ) -> InputPartitions:
         return InputPartitions(
             {
-                name: connection.read_graph_partitions(
-                    snapshot.name, snapshot.id, snapshot.graph.artifact_to_key[artifact], artifact
+                name: connection.read_snapshot_partitions(
+                    snapshot, snapshot.graph.artifact_to_key[artifact], artifact
                 )
                 for name, artifact in producer.inputs.items()
             }
@@ -51,12 +51,8 @@ class Executor(Model):
             for output in snapshot.graph.producer_outputs[producer]
         }
         for artifact, partitions in existing_output_partitions.items():
-            connection.write_graph_partitions(
-                snapshot.name,
-                snapshot.id,
-                snapshot.graph.artifact_to_key[artifact],
-                artifact,
-                partitions,
+            connection.write_snapshot_partitions(
+                snapshot, snapshot.graph.artifact_to_key[artifact], artifact, partitions
             )
         # TODO: Guarantee all outputs have the same set of identified partitions. Currently, this
         # pretends a partition is built for all outputs if _any_ are built for that partition.


### PR DESCRIPTION
# Description

Adds new methods to `Backend` to support persisting and retrieving `Graph`s + `GraphSnapshot`s and retrieving `GraphSnapshot`s from a tag. This also changes a couple of the other `Backend` methods to accept a `GraphSnapshot` instance instead of a `name, snapshot_id` pair.

While working on this, I noticed that `hash(graph)` could change, even though the models are (intended to be) immutable. This turned out to be due to `@cached_property`s, which are now ignored and fixed in https://github.com/artigraph/artigraph/commit/6626530de54617d75b1f71f9527b3dcd51362648.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Updated tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in upstream modules
