### PR TITLE
Use __future__.annotations

### DIFF
--- a/src/arti/annotations/__init__.py
+++ b/src/arti/annotations/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from arti.internal.models import Model

--- a/src/arti/artifacts/__init__.py
+++ b/src/arti/artifacts/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 import json
@@ -43,7 +45,7 @@ class Artifact(Model):
     #
     # ProducerOutput is a ForwardRef/cyclic import. Quote the entire hint to force full resolution
     # during `.update_forward_refs`, rather than `Optional[ForwardRef("ProducerOutput")]`.
-    producer_output: "Optional[ProducerOutput]" = Field(None, repr=False)
+    producer_output: Optional[ProducerOutput] = Field(None, repr=False)
 
     # NOTE: Narrow the fields that affect the fingerprint to minimize changes (which trigger
     # recompute). Importantly, avoid fingerprinting the `.producer_output` (ie: the *upstream*
@@ -73,7 +75,7 @@ class Artifact(Model):
         return tuple(chain(get_field_default(cls, field.name) or (), value))
 
     @classmethod
-    def cast(cls, value: Any) -> "Artifact":
+    def cast(cls, value: Any) -> Artifact:
         """Attempt to convert an arbitrary value to an appropriate Artifact instance.
 
         `Artifact.cast` is used to convert values assigned to an `ArtifactBox` (such as

--- a/src/arti/executors/local.py
+++ b/src/arti/executors/local.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from graphlib import TopologicalSorter
 

--- a/src/arti/formats/__init__.py
+++ b/src/arti/formats/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from typing import ClassVar, Optional
@@ -29,7 +31,7 @@ class Format(Model):
         return type_
 
     @classmethod
-    def get_default(cls) -> "Format":
+    def get_default(cls) -> Format:
         from arti.formats.json import JSON
 
         return JSON()  # TODO: Support some sort of configurable defaults.

--- a/src/arti/formats/json.py
+++ b/src/arti/formats/json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from arti.formats import Format
 from arti.types.python import python_type_system
 

--- a/src/arti/formats/pickle.py
+++ b/src/arti/formats/pickle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from arti.formats import Format
 from arti.types.python import python_type_system
 

--- a/src/arti/internal/__init__.py
+++ b/src/arti/internal/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
 from contextlib import contextmanager
 

--- a/src/arti/internal/dispatch.py
+++ b/src/arti/internal/dispatch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from collections.abc import Callable
 from typing import Any, Optional, TypeVar, cast, overload

--- a/src/arti/internal/patches.py
+++ b/src/arti/internal/patches.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import no_type_check
 
 

--- a/src/arti/internal/type_hints.py
+++ b/src/arti/internal/type_hints.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import sys
 import types

--- a/src/arti/internal/vendored/setuptools.py
+++ b/src/arti/internal/vendored/setuptools.py
@@ -7,6 +7,8 @@ Type hints have been added to pass `mypy` strict mode.
 
 1: https://github.com/pypa/setuptools/tree/c65e3380b0a18c92a0fc2d2b770b17cfaaec054b
 """
+from __future__ import annotations
+
 import os
 from collections.abc import Callable, Generator, Iterable
 from fnmatch import fnmatchcase

--- a/src/arti/io/__init__.py
+++ b/src/arti/io/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from collections.abc import Sequence

--- a/src/arti/io/json_gcsfile_python.py
+++ b/src/arti/io/json_gcsfile_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Sequence
 from itertools import chain

--- a/src/arti/io/json_localfile_python.py
+++ b/src/arti/io/json_localfile_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Sequence
 from itertools import chain

--- a/src/arti/io/json_stringliteral_python.py
+++ b/src/arti/io/json_stringliteral_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Sequence
 from itertools import chain

--- a/src/arti/io/pickle_gcsfile_python.py
+++ b/src/arti/io/pickle_gcsfile_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from collections.abc import Sequence
 from itertools import chain

--- a/src/arti/io/pickle_localfile_python.py
+++ b/src/arti/io/pickle_localfile_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from collections.abc import Sequence
 from itertools import chain

--- a/src/arti/partitions/__init__.py
+++ b/src/arti/partitions/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 import abc
@@ -17,7 +19,7 @@ class key_component(property):
 
 class PartitionKey(Model):
     _abstract_ = True
-    _by_type_: "ClassVar[dict[type[Type], type[PartitionKey]]]" = {}
+    _by_type_: ClassVar[dict[type[Type], type[PartitionKey]]] = {}
 
     default_key_components: ClassVar[frozendict[str, str]]
     matching_type: ClassVar[type[Type]]
@@ -30,7 +32,7 @@ class PartitionKey(Model):
         for attr in ("default_key_components", "matching_type"):
             if not hasattr(cls, attr):
                 raise TypeError(f"{cls.__name__} must set `{attr}`")
-        if unknown := (set(cls.default_key_components) - cls.key_components):
+        if unknown := set(cls.default_key_components) - cls.key_components:
             raise TypeError(
                 f"Unknown key_components in {cls.__name__}.default_key_components: {unknown}"
             )
@@ -44,15 +46,15 @@ class PartitionKey(Model):
 
     @classmethod
     @abc.abstractmethod
-    def from_key_components(cls, **key_components: str) -> "PartitionKey":
+    def from_key_components(cls, **key_components: str) -> PartitionKey:
         raise NotImplementedError(f"Unable to parse '{cls.__name__}' from: {key_components}")
 
     @classmethod
-    def get_class_for(cls, type_: Type) -> type["PartitionKey"]:
+    def get_class_for(cls, type_: Type) -> type[PartitionKey]:
         return cls._by_type_[type(type_)]
 
     @classmethod
-    def types_from(cls, type_: Type) -> "CompositeKeyTypes":
+    def types_from(cls, type_: Type) -> CompositeKeyTypes:
         if not isinstance(type_, Collection):
             return frozendict()
         return frozendict(

--- a/src/arti/producers/__init__.py
+++ b/src/arti/producers/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from collections.abc import Callable, Iterator

--- a/src/arti/statistics/__init__.py
+++ b/src/arti/statistics/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from arti.internal.models import Model

--- a/src/arti/storage/_internal.py
+++ b/src/arti/storage/_internal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import string
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
@@ -23,11 +25,11 @@ class FormatPlaceholder(Placeholder):
             result += ":" + spec
         return "{" + result + "}"
 
-    def __getitem__(self, key: Any) -> "FormatPlaceholder":
+    def __getitem__(self, key: Any) -> FormatPlaceholder:
         self._key = f"{self._key}[{key}]"
         return self
 
-    def __getattr__(self, attr: str) -> "FormatPlaceholder":
+    def __getattr__(self, attr: str) -> FormatPlaceholder:
         self._key = f"{self._key}.{attr}"
         return self
 
@@ -35,7 +37,7 @@ class FormatPlaceholder(Placeholder):
 # Used to convert things like `/{date_key.Y[1970]` to `/{date_key.Y` so we can format in
 # *real* partition key values.
 class StripIndexPlaceholder(FormatPlaceholder):
-    def __getitem__(self, key: Any) -> "StripIndexPlaceholder":
+    def __getitem__(self, key: Any) -> StripIndexPlaceholder:
         return self
 
 
@@ -50,7 +52,7 @@ class WildcardPlaceholder(Placeholder):
     @classmethod
     def with_key_types(
         cls, key_types: Mapping[str, type[PartitionKey]]
-    ) -> Callable[[str], "WildcardPlaceholder"]:
+    ) -> Callable[[str], WildcardPlaceholder]:
         return partial(cls, key_types=key_types)
 
     def _err_if_no_attribute(self) -> None:
@@ -60,7 +62,7 @@ class WildcardPlaceholder(Placeholder):
                 f"'{self._key}' cannot be used directly in a partition path; access one of the key components (eg: '{self._key}.{example}')."
             )
 
-    def __getattr__(self, name: str) -> "WildcardPlaceholder":
+    def __getattr__(self, name: str) -> WildcardPlaceholder:
         if self._attribute is not None:
             raise ValueError(
                 f"'{self._key}.{self._attribute}.{name}' cannot be used in a partition path; only immediate '{self._key}' attributes (such as '{self._attribute}') can be used."

--- a/src/arti/storage/google/cloud/storage.py
+++ b/src/arti/storage/google/cloud/storage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from gcsfs import GCSFileSystem

--- a/src/arti/storage/literal.py
+++ b/src/arti/storage/literal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from arti.fingerprints import Fingerprint

--- a/src/arti/thresholds/__init__.py
+++ b/src/arti/thresholds/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from typing import Any, ClassVar

--- a/src/arti/types/__init__.py
+++ b/src/arti/types/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from abc import abstractmethod
@@ -308,7 +310,7 @@ class TypeAdapter:
         return isinstance(type_, cls.artigraph)
 
     @classmethod
-    def to_artigraph(cls, type_: Any, *, hints: dict[str, Any], type_system: "TypeSystem") -> Type:
+    def to_artigraph(cls, type_: Any, *, hints: dict[str, Any], type_system: TypeSystem) -> Type:
         raise NotImplementedError()
 
     @classmethod
@@ -316,7 +318,7 @@ class TypeAdapter:
         raise NotImplementedError()
 
     @classmethod
-    def to_system(cls, type_: Type, *, hints: dict[str, Any], type_system: "TypeSystem") -> Any:
+    def to_system(cls, type_: Type, *, hints: dict[str, Any], type_system: TypeSystem) -> Any:
         raise NotImplementedError()
 
 
@@ -324,7 +326,7 @@ class TypeAdapter:
 # python TypeSystem).
 class _ScalarClassTypeAdapter(TypeAdapter):
     @classmethod
-    def to_artigraph(cls, type_: Any, *, hints: dict[str, Any], type_system: "TypeSystem") -> Type:
+    def to_artigraph(cls, type_: Any, *, hints: dict[str, Any], type_system: TypeSystem) -> Type:
         return cls.artigraph()
 
     @classmethod
@@ -332,7 +334,7 @@ class _ScalarClassTypeAdapter(TypeAdapter):
         return lenient_issubclass(type_, cls.system)
 
     @classmethod
-    def to_system(cls, type_: Type, *, hints: dict[str, Any], type_system: "TypeSystem") -> Any:
+    def to_system(cls, type_: Type, *, hints: dict[str, Any], type_system: TypeSystem) -> Any:
         return cls.system
 
     @classmethod
@@ -342,7 +344,7 @@ class _ScalarClassTypeAdapter(TypeAdapter):
         artigraph: type[Type],
         system: Any,
         priority: int = 0,
-        type_system: "TypeSystem",
+        type_system: TypeSystem,
         name: Optional[str] = None,
     ) -> type[TypeAdapter]:
         """Generate a _ScalarClassTypeAdapter subclass for the scalar system type."""
@@ -358,7 +360,7 @@ class _ScalarClassTypeAdapter(TypeAdapter):
 
 class TypeSystem(Model):
     key: str
-    extends: "tuple[TypeSystem, ...]" = ()
+    extends: tuple[TypeSystem, ...] = ()
 
     # NOTE: Use a NoCopyDict to avoid copies of the registry. Otherwise, TypeSystems that extend
     # this TypeSystem will only see the adapters registered *as of initialization* (as pydantic
@@ -373,7 +375,7 @@ class TypeSystem(Model):
         return reversed(sorted(self._adapter_by_key.values(), key=attrgetter("priority")))
 
     def to_artigraph(
-        self, type_: Any, *, hints: dict[str, Any], root_type_system: "Optional[TypeSystem]" = None
+        self, type_: Any, *, hints: dict[str, Any], root_type_system: Optional[TypeSystem] = None
     ) -> Type:
         root_type_system = root_type_system or self
         for adapter in self._priority_sorted_adapters:
@@ -389,7 +391,7 @@ class TypeSystem(Model):
         raise NotImplementedError(f"No {root_type_system} adapter for system type: {type_}.")
 
     def to_system(
-        self, type_: Type, *, hints: dict[str, Any], root_type_system: "Optional[TypeSystem]" = None
+        self, type_: Type, *, hints: dict[str, Any], root_type_system: Optional[TypeSystem] = None
     ) -> Any:
         root_type_system = root_type_system or self
         for adapter in self._priority_sorted_adapters:

--- a/src/arti/types/bigquery.py
+++ b/src/arti/types/bigquery.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from copy import deepcopy
 from typing import Any

--- a/src/arti/types/pydantic.py
+++ b/src/arti/types/pydantic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Protocol
 
 from pydantic import BaseModel

--- a/src/arti/types/python.py
+++ b/src/arti/types/python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from collections.abc import Mapping
 from functools import partial

--- a/src/arti/versions/__init__.py
+++ b/src/arti/versions/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 import inspect

--- a/src/arti/views/__init__.py
+++ b/src/arti/views/__init__.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
 import builtins
 from typing import Any, ClassVar, Literal, Optional, get_origin
 
@@ -21,7 +24,7 @@ class View(Model):
     """
 
     _abstract_ = True
-    _by_python_type_: "ClassVar[dict[Optional[type], type[View]]]" = {}
+    _by_python_type_: ClassVar[dict[Optional[type], type[View]]] = {}
 
     priority: ClassVar[int] = 0  # Set priority of this view for its python_type. Higher is better.
     python_type: ClassVar[Optional[type]]
@@ -83,7 +86,7 @@ class View(Model):
         return {"artifact_class": artifact_class, "type": type_}
 
     @classmethod  # TODO: Use typing.Self for return, pending mypy support
-    def get_class_for(cls, annotation: Any) -> builtins.type["View"]:
+    def get_class_for(cls, annotation: Any) -> builtins.type[View]:
         view_class = get_item_from_annotated(annotation, cls, is_subclass=True)
         if view_class is None:
             # We've already searched for a View instance in the original Annotated args, so just
@@ -103,7 +106,7 @@ class View(Model):
         return view_class
 
     @classmethod  # TODO: Use typing.Self for return, pending mypy support
-    def from_annotation(cls, annotation: Any, *, mode: MODE) -> "View":
+    def from_annotation(cls, annotation: Any, *, mode: MODE) -> View:
         view_class = cls.get_class_for(annotation)
         view = view_class(mode=mode, **cls._get_kwargs_from_annotation(annotation))
         view.check_annotation_compatibility(annotation)

--- a/src/arti/views/python.py
+++ b/src/arti/views/python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime
 
 from arti.types.python import python_type_system


### PR DESCRIPTION
# Description

I previously removed `from __future__ import annotations` in https://github.com/artigraph/artigraph/pull/116, but the original pydantic bug has been fixed. This adds the import back and tidies the manually stringized hints.
