### PR TITLE
Use grouped dependabot updates and change to Monday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,11 +3,19 @@ version: 2
 updates:
 - package-ecosystem: pip
   directory: /
+  groups:
+    deps:
+      patterns:
+        - "*"
   schedule:
     interval: weekly
-    day: "saturday"
+    day: "monday"
 - package-ecosystem: github-actions
   directory: /
+  groups:
+    deps:
+      patterns:
+        - "*"
   schedule:
     interval: weekly
-    day: "saturday"
+    day: "monday"


### PR DESCRIPTION
# Description

Upgrades don't break that often and the single PR will be less work to merge week-to-week.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
