### PR TITLE
Disable implicit multiline string concatenation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,9 @@ ignore = [
     "S101",   # use of assert (used for mypy type narrowing)
 ]
 
+[tool.ruff.flake8-implicit-str-concat]
+allow-multiline = false
+
 [tool.ruff.isort]
 known-first-party = ["tests"]
 


### PR DESCRIPTION
# Description

Implicit concats are easy to miss, particular when mixed with other function arguments.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
