### PR TITLE
Add StoragePartition.storage reference

### DIFF
--- a/src/arti/storage/__init__.py
+++ b/src/arti/storage/__init__.py
@@ -6,7 +6,7 @@ import abc
 import os
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar
 
-from pydantic import PrivateAttr
+from pydantic import Field, PrivateAttr
 
 from arti.fingerprints import Fingerprint
 from arti.formats import Format
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 
 class StoragePartition(Model):
+    storage: Storage[StoragePartition] = Field(repr=False)
     keys: CompositeKey = CompositeKey()
     input_fingerprint: Fingerprint = Fingerprint.empty()
     content_fingerprint: Fingerprint = Fingerprint.empty()
@@ -186,7 +187,7 @@ class Storage(Model, Generic[StoragePartitionVar_co]):
             if name in self.storage_partition_type.__fields__
         }
         partition = self.storage_partition_type(
-            input_fingerprint=input_fingerprint, keys=keys, **field_values
+            input_fingerprint=input_fingerprint, keys=keys, storage=self, **field_values
         )
         if with_content_fingerprint:
             partition = partition.with_content_fingerprint()
@@ -215,3 +216,6 @@ class Storage(Model, Generic[StoragePartitionVar_co]):
                 if (new := self._resolve_field(name, original, values)) != original
             }
         )
+
+
+StoragePartition.update_forward_refs()

--- a/tests/arti/io/test_literal_io.py
+++ b/tests/arti/io/test_literal_io.py
@@ -37,10 +37,10 @@ def test_stringliteral_io() -> None:
     ) == [{"a": 1}, {"a": 2}]
     # Check that read with value=None fails
     with pytest.raises(FileNotFoundError, match="Literal has not been written yet"):
-        io.read(a.type, a.format, [StringLiteralPartition(id="junk")], view=view)
+        io.read(a.type, a.format, [StringLiteralPartition(id="junk", storage=a.storage)], view=view)
 
     # Test write
-    unwritten = StringLiteralPartition(id="junk")
+    unwritten = StringLiteralPartition(id="junk", storage=a.storage)
     new = io.write(10, a.type, a.format, unwritten, view=view)
     assert isinstance(new, StringLiteralPartition)
     assert new.value == json.dumps(10)

--- a/tests/arti/storage/test_literal_storage.py
+++ b/tests/arti/storage/test_literal_storage.py
@@ -21,10 +21,15 @@ def test_StringLiteral() -> None:
     # Confirm value=None returns no partitions
     assert not StringLiteral(id="test")._visit_type(t)._visit_format(f).discover_partitions()
     # Confirm keys/input_fingerprint validators don't error for empty values
-    assert partition == StringLiteralPartition(id="test", value="test").with_content_fingerprint()
+    assert (
+        partition
+        == StringLiteralPartition(
+            id="test", value="test", storage=literal
+        ).with_content_fingerprint()
+    )
     # Confirm empty value raises
     with pytest.raises(FileNotFoundError, match="Literal has not been written yet"):
-        StringLiteralPartition(id="test").compute_content_fingerprint()
+        StringLiteralPartition(id="test", storage=literal).compute_content_fingerprint()
 
 
 def test_StringLiteral_errors() -> None:

--- a/tests/arti/storage/test_local_storage.py
+++ b/tests/arti/storage/test_local_storage.py
@@ -129,8 +129,9 @@ def test_local_file_partition_fingerprint(tmp_path: Path) -> None:
     path = tmp_path / "test.txt"
     with path.open("w") as f:
         f.write("hello world")
-
-    partition = LocalFilePartition(keys={}, path=str(path)).with_content_fingerprint()
+    partition = LocalFilePartition(
+        keys={}, path=str(path), storage=LocalFile(path=str(path))
+    ).with_content_fingerprint()
     assert partition.content_fingerprint == Fingerprint.from_string(
         hashlib.sha256(text.encode()).hexdigest()
     )

--- a/tests/arti/storage/test_storage.py
+++ b/tests/arti/storage/test_storage.py
@@ -45,7 +45,7 @@ class MockStorage(Storage[MockStoragePartition]):
 
 
 def test_StoragePartition_content_fingerprint() -> None:
-    sp = MockStoragePartition(path="/tmp/test", keys={})
+    sp = MockStoragePartition(path="/tmp/test", keys={}, storage=MockStorage(path="/tmp/test"))
     assert sp.content_fingerprint == Fingerprint.empty()
     populated = sp.with_content_fingerprint()
     assert sp.content_fingerprint == Fingerprint.empty()
@@ -201,7 +201,7 @@ def test_Storage_generate_partition() -> None:
         ._visit_format(DummyFormat())
     )
     expected_partition = MockStoragePartition(
-        input_fingerprint=input_fingerprint, keys=keys, path="05/10"
+        input_fingerprint=input_fingerprint, keys=keys, path="05/10", storage=s
     )
 
     output = s.generate_partition(keys=keys, input_fingerprint=input_fingerprint)

--- a/tests/arti/views/test_python.py
+++ b/tests/arti/views/test_python.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from arti import Artifact, View, read, write
 from arti.formats.pickle import Pickle
 from arti.internal.utils import named_temporary_file
-from arti.storage.local import LocalFilePartition
+from arti.storage.local import LocalFile, LocalFilePartition
 from arti.views.python import Date, Datetime, Dict, Float, Int, Null, Str
 
 
@@ -24,10 +24,9 @@ def test_python_View() -> None:
         assert view.type == view.type_system.to_artigraph(python_type, hints={})
 
         test_format = Pickle()
-
         binary = pickle.dumps(val)
         with named_temporary_file("w+b") as f:
-            test_storage_partition = LocalFilePartition(path=f.name)
+            test_storage_partition = LocalFilePartition(path=f.name, storage=LocalFile())
 
             f.write(binary)
             f.seek(0)


### PR DESCRIPTION
# Description

This adds `StoragePartition.storage` to provide a back reference, contributed with @JamesOswald. In particular, this is useful for `Backend.{read,write}_artifact_partitions`, which identifies partitions that may match a given Artifact _even if not (yet) associated with the current `GraphSnapshot`_ (for example, we change something that changes the `GraphSnapshot`, but the inputs to this particular `Artifact` haven't changed). The (simplified) model is something like:

![storage_partition](https://github.com/artigraph/artigraph/assets/2555532/eeab650d-3a57-4429-81da-43327642bcff)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
