### PR TITLE
Rename Connection to BackendConnection

### DIFF
--- a/src/arti/__init__.py
+++ b/src/arti/__init__.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from arti.annotations import Annotation
 from arti.artifacts import Artifact
-from arti.backends import Backend, Connection
+from arti.backends import Backend, BackendConnection
 from arti.executors import Executor
 from arti.fingerprints import Fingerprint
 from arti.formats import Format
@@ -30,9 +30,9 @@ __all__ = [
     "Annotation",
     "Artifact",
     "Backend",
+    "BackendConnection",
     "CompositeKey",
     "CompositeKeyTypes",
-    "Connection",
     "Executor",
     "Fingerprint",
     "Format",

--- a/src/arti/backends/__init__.py
+++ b/src/arti/backends/__init__.py
@@ -27,11 +27,11 @@ if TYPE_CHECKING:
 # bunch of low level calls, each own network call), Backend can override.
 
 
-class Connection:
-    """Connection is a wrapper around an active connection to a Backend resource.
+class BackendConnection:
+    """BackendConnection is a wrapper around an active connection to a Backend resource.
 
     For example, a Backend connecting to a database might wrap up a SQLAlchemy connection in a
-    Connection subclass implementing the required methods.
+    BackendConnection subclass implementing the required methods.
     """
 
     # Artifact partitions - independent of a specific GraphSnapshot
@@ -134,18 +134,18 @@ class Connection:
     def __get_validators__(cls) -> list[Callable[[Any, ModelField], Any]]:
         """Return an empty list of "validators".
 
-        Allows using a Connection (which is not a model) as a field in other models without setting
-        `arbitrary_types_allowed` (which applies broadly). [1].
+        Allows using a BackendConnection (which is not a model) as a field in other models without
+        setting `arbitrary_types_allowed` (which applies broadly). [1].
 
         1: https://docs.pydantic.dev/usage/types/#generic-classes-as-types
         """
         return []
 
 
-ConnectionVar = TypeVar("ConnectionVar", bound=Connection, covariant=True)
+BackendConnectionVar = TypeVar("BackendConnectionVar", bound=BackendConnection, covariant=True)
 
 
-class Backend(Model, Generic[ConnectionVar]):
+class Backend(Model, Generic[BackendConnectionVar]):
     """Backend represents a storage for internal Artigraph metadata.
 
     Backend storage is an addressable location (local path, database connection, etc) that
@@ -158,5 +158,5 @@ class Backend(Model, Generic[ConnectionVar]):
 
     @contextmanager
     @abstractmethod
-    def connect(self) -> Iterator[ConnectionVar]:
+    def connect(self) -> Iterator[BackendConnectionVar]:
         raise NotImplementedError()

--- a/src/arti/backends/memory.py
+++ b/src/arti/backends/memory.py
@@ -10,7 +10,7 @@ from pydantic import PrivateAttr
 from arti import (
     Artifact,
     Backend,
-    Connection,
+    BackendConnection,
     Fingerprint,
     Graph,
     GraphSnapshot,
@@ -61,7 +61,7 @@ class _NoCopyContainer(NoCopyMixin):
         self.storage_partitions: _StoragePartitions = defaultdict(set[StoragePartition])
 
 
-class MemoryConnection(Connection):
+class MemoryConnection(BackendConnection):
     def __init__(self, container: _NoCopyContainer) -> None:
         self.container = container
 

--- a/src/arti/executors/__init__.py
+++ b/src/arti/executors/__init__.py
@@ -6,7 +6,7 @@ import abc
 import logging
 from itertools import chain
 
-from arti.backends import Connection
+from arti.backends import BackendConnection
 from arti.fingerprints import Fingerprint
 from arti.graphs import GraphSnapshot
 from arti.internal.models import Model
@@ -22,7 +22,7 @@ class Executor(Model):
         raise NotImplementedError()
 
     def get_producer_inputs(
-        self, snapshot: GraphSnapshot, connection: Connection, producer: Producer
+        self, snapshot: GraphSnapshot, connection: BackendConnection, producer: Producer
     ) -> InputPartitions:
         return InputPartitions(
             {
@@ -36,7 +36,7 @@ class Executor(Model):
     def discover_producer_partitions(
         self,
         snapshot: GraphSnapshot,
-        connection: Connection,
+        connection: BackendConnection,
         producer: Producer,
         *,
         partition_input_fingerprints: InputFingerprints,
@@ -63,7 +63,7 @@ class Executor(Model):
     def build_producer_partition(
         self,
         snapshot: GraphSnapshot,
-        connection: Connection,
+        connection: BackendConnection,
         producer: Producer,
         *,
         existing_partition_keys: set[CompositeKey],


### PR DESCRIPTION
# Description

Renames `Connection` to `BackendConnection` to clarify use (especially on `from arti import ...`). This also aligns with the `StoragePartition` naming as a "component" of `Storage`. Contributed with @JamesOswald as part of the neo4j work

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
