### PR TITLE
Support None input to Fingerprint.from_* constructors and warn on invalid Fingerprint.fingerprint use

### DIFF
--- a/src/arti/fingerprints/__init__.py
+++ b/src/arti/fingerprints/__init__.py
@@ -55,23 +55,31 @@ class Fingerprint(Model):
         return cls(key=None)
 
     @classmethod
-    def from_int(cls, x: int, /) -> Fingerprint:
+    def from_int(cls, x: Optional[int], /) -> Fingerprint:
+        if x is None:
+            return cls.empty()
         return cls.from_int64(int64(x))
 
     @classmethod
-    def from_int64(cls, x: int64, /) -> Fingerprint:
+    def from_int64(cls, x: Optional[int64], /) -> Fingerprint:
+        if x is None:
+            return cls.empty()
         return cls(key=x)
 
     @classmethod
-    def from_string(cls, x: str, /) -> Fingerprint:
+    def from_string(cls, x: Optional[str], /) -> Fingerprint:
         """Fingerprint an arbitrary string.
 
         Fingerprints using Farmhash Fingerprint64, converted to int64 via two's complement.
         """
+        if x is None:
+            return cls.empty()
         return cls.from_uint64(uint64(farmhash.fingerprint64(x)))
 
     @classmethod
-    def from_uint64(cls, x: uint64, /) -> Fingerprint:
+    def from_uint64(cls, x: Optional[uint64], /) -> Fingerprint:
+        if x is None:
+            return cls.empty()
         return cls.from_int64(int64(x))
 
     @classmethod

--- a/src/arti/fingerprints/__init__.py
+++ b/src/arti/fingerprints/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 import operator
+import warnings
 from collections.abc import Callable
 from functools import reduce
 from typing import Optional, Union
@@ -77,6 +78,11 @@ class Fingerprint(Model):
     def identity(cls) -> Fingerprint:
         """Return a Fingerprint that, when combined, will return the other Fingerprint."""
         return cls(key=int64(0))
+
+    @property
+    def fingerprint(self) -> Fingerprint:
+        warnings.warn("`Fingerprint.fingerprint` returns itself", stacklevel=2)
+        return self
 
     @property
     def is_empty(self) -> bool:

--- a/src/arti/internal/models.py
+++ b/src/arti/internal/models.py
@@ -163,8 +163,12 @@ class Model(BaseModel):
         # which wrecks havoc if a model is a key in a dict (`key in mydict` will be `False`...).
         #
         # This is only safe as the models are (mostly) frozen.
-        assert (key := self.fingerprint.key) is not None
-        return key
+        from arti.fingerprints import Fingerprint
+
+        fingerprint = self if isinstance(self, Fingerprint) else self.fingerprint
+        if fingerprint.key is None:
+            return 0
+        return int(fingerprint.key)
 
     # Omitting unpassed args in repr by default
     def __repr_args__(self) -> Sequence[tuple[Optional[str], Any]]:

--- a/tests/arti/test_fingerprints.py
+++ b/tests/arti/test_fingerprints.py
@@ -10,9 +10,13 @@ def test_Fingerprint() -> None:
     assert Fingerprint(key=int64(5)).key == 5
     assert Fingerprint.empty().key is None
     assert Fingerprint.from_int(-5) == -5
+    assert Fingerprint.from_int(None) == Fingerprint.empty()
+    assert Fingerprint.from_int64(None) == Fingerprint.empty()
     assert Fingerprint.from_int64(int64(-5)) == -5
     assert Fingerprint.from_string("OK") == -7962813320811223369
     assert Fingerprint.from_string("ok") == 5227454011934222951
+    assert Fingerprint.from_string(None) == Fingerprint.empty()
+    assert Fingerprint.from_uint64(None) == Fingerprint.empty()
     assert Fingerprint.from_uint64(uint64(5)) == 5
     assert Fingerprint.from_uint64(uint64(int64(-5))) == -5
     assert Fingerprint.identity() == 0

--- a/tests/arti/test_fingerprints.py
+++ b/tests/arti/test_fingerprints.py
@@ -30,6 +30,9 @@ def test_Fingerprint() -> None:
     assert not Fingerprint.empty().is_identity
     assert not Fingerprint.identity().is_empty
 
+    with pytest.warns(match="returns itself"):
+        assert f1.fingerprint is f1
+
 
 def test_Fingerprint_math() -> None:
     f1, f2, f3, f4, f5 = (Fingerprint(key=int64(i)) for i in range(5))


### PR DESCRIPTION
# Description

cc @JamesOswald

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
