### PR TITLE
Change Fingerprint to be an int(64) subclass instead of a Model

### DIFF
--- a/src/arti/executors/local.py
+++ b/src/arti/executors/local.py
@@ -6,6 +6,7 @@ from graphlib import TopologicalSorter
 from arti.artifacts import Artifact
 from arti.executors import Executor
 from arti.graphs import GraphSnapshot
+from arti.internal.type_hints import assert_not_none
 from arti.producers import Producer
 
 
@@ -45,7 +46,9 @@ class LocalExecutor(Executor):
                             backend,
                             node,
                             existing_partition_keys=existing_keys,
-                            input_fingerprint=partition_input_fingerprints[partition_key],
+                            input_fingerprint=assert_not_none(
+                                partition_input_fingerprints[partition_key]
+                            ),
                             partition_dependencies=dependencies,
                             partition_key=partition_key,
                         )

--- a/src/arti/fingerprints/__init__.py
+++ b/src/arti/fingerprints/__init__.py
@@ -3,112 +3,51 @@ from __future__ import annotations
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 import operator
-import warnings
-from collections.abc import Callable
 from functools import reduce
-from typing import Optional, Union
 
 import farmhash
 
-from arti.internal.models import Model
 from arti.internal.utils import int64, uint64
 
 
-def _gen_fingerprint_binop(
-    op: Callable[[int, int], int]
-) -> Callable[[Fingerprint, Union[int, Fingerprint]], Fingerprint]:
-    def _fingerprint_binop(self: Fingerprint, other: Union[int, Fingerprint]) -> Fingerprint:
-        if isinstance(other, int):
-            other = Fingerprint.from_int(other)
-        if isinstance(other, Fingerprint):
-            if self.key is None or other.key is None:
-                return Fingerprint.empty()
-            return Fingerprint(key=op(self.key, other.key))
-        return NotImplemented
-
-    return _fingerprint_binop
-
-
-class Fingerprint(Model):
+class Fingerprint(int64):
     """Fingerprint represents a unique identity as an int64 value.
 
     Using an int(64) has a number of convenient properties:
     - can be combined independent of order with XOR
     - can be stored relatively cheaply
-    - empty 0 values drop out when combined (5 ^ 0 = 5)
+    - 0 acts as an "identity" value when combined (5 ^ 0 = 5)
     - is relatively cross-platform (across databases, languages, etc)
-
-    There are two "special" Fingerprints w/ factory functions that, when combined with other
-    Fingerprints:
-    - `empty()`: returns `empty()`
-    - `identity()`: return the other Fingerprint
     """
-
-    key: Optional[int64]
 
     def combine(self, *others: Fingerprint) -> Fingerprint:
         return reduce(operator.xor, others, self)
 
     @classmethod
-    def empty(cls) -> Fingerprint:
-        """Return a Fingerprint that, when combined, will return Fingerprint.empty()"""
-        return cls(key=None)
-
-    @classmethod
-    def from_int(cls, x: Optional[int], /) -> Fingerprint:
-        if x is None:
-            return cls.empty()
+    def from_int(cls, x: int, /) -> Fingerprint:
         return cls.from_int64(int64(x))
 
     @classmethod
-    def from_int64(cls, x: Optional[int64], /) -> Fingerprint:
-        if x is None:
-            return cls.empty()
-        return cls(key=x)
+    def from_int64(cls, x: int64, /) -> Fingerprint:
+        return cls(x)
 
     @classmethod
-    def from_string(cls, x: Optional[str], /) -> Fingerprint:
+    def from_string(cls, x: str, /) -> Fingerprint:
         """Fingerprint an arbitrary string.
 
         Fingerprints using Farmhash Fingerprint64, converted to int64 via two's complement.
         """
-        if x is None:
-            return cls.empty()
         return cls.from_uint64(uint64(farmhash.fingerprint64(x)))
 
     @classmethod
-    def from_uint64(cls, x: Optional[uint64], /) -> Fingerprint:
-        if x is None:
-            return cls.empty()
+    def from_uint64(cls, x: uint64, /) -> Fingerprint:
         return cls.from_int64(int64(x))
 
     @classmethod
     def identity(cls) -> Fingerprint:
         """Return a Fingerprint that, when combined, will return the other Fingerprint."""
-        return cls(key=int64(0))
-
-    @property
-    def fingerprint(self) -> Fingerprint:
-        warnings.warn("`Fingerprint.fingerprint` returns itself", stacklevel=2)
-        return self
-
-    @property
-    def is_empty(self) -> bool:
-        return self.key is None
+        return cls(0)
 
     @property
     def is_identity(self) -> bool:
-        return self.key == 0
-
-    __and__ = _gen_fingerprint_binop(operator.__and__)
-    __lshift__ = _gen_fingerprint_binop(operator.__lshift__)
-    __or__ = _gen_fingerprint_binop(operator.__or__)
-    __rshift__ = _gen_fingerprint_binop(operator.__rshift__)
-    __xor__ = _gen_fingerprint_binop(operator.__xor__)
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, int):
-            other = Fingerprint.from_int(other)
-        if isinstance(other, Fingerprint):
-            return self.key == other.key
-        return NotImplemented
+        return self == 0

--- a/src/arti/graphs/__init__.py
+++ b/src/arti/graphs/__init__.py
@@ -80,7 +80,7 @@ class ArtifactBox(TypedBox[Artifact]):
         # copying the instance and setting the `producer_output` attribute). We won't know the
         # "final" instance until assignment here to the Graph.
         if artifact.producer_output is None:
-            storage = storage._visit_input_fingerprint(Fingerprint.empty())
+            storage = storage._visit_input_fingerprint(None)
         elif not artifact.storage.includes_input_fingerprint_template:
             raise ValueError(
                 "Produced Artifacts must have a '{input_fingerprint}' template in their Storage"
@@ -248,7 +248,7 @@ class Graph(Model):
         data: Any,
         *,
         artifact: Artifact,
-        input_fingerprint: Fingerprint = Fingerprint.empty(),
+        input_fingerprint: Optional[Fingerprint] = None,
         keys: CompositeKey = CompositeKey(),
         view: Optional[View] = None,
         snapshot: Optional[GraphSnapshot] = None,
@@ -345,9 +345,6 @@ class GraphSnapshot(Model):
                     snapshot_id = snapshot_id.combine(
                         *[partition.fingerprint for partition in known_artifact_partitions[key]]
                     )
-        if snapshot_id.is_empty or snapshot_id.is_identity:  # pragma: no cover
-            # NOTE: This shouldn't happen unless the logic above is faulty.
-            raise ValueError("Fingerprint is empty!")
         snapshot = cls(graph=graph, id=snapshot_id)
         # Write the discovered partitions (if not already known) and link to this new snapshot.
         with (connection or snapshot.backend).connect() as conn:
@@ -407,7 +404,7 @@ class GraphSnapshot(Model):
         data: Any,
         *,
         artifact: Artifact,
-        input_fingerprint: Fingerprint = Fingerprint.empty(),
+        input_fingerprint: Optional[Fingerprint] = None,
         keys: CompositeKey = CompositeKey(),
         view: Optional[View] = None,
         connection: Optional[BackendConnection] = None,

--- a/src/arti/internal/type_hints.py
+++ b/src/arti/internal/type_hints.py
@@ -24,6 +24,11 @@ _T = TypeVar("_T")
 NoneType = cast(type, type(None))  # mypy otherwise treats type(None) as an object
 
 
+def assert_not_none(v: Optional[_T]) -> _T:
+    assert v is not None
+    return v
+
+
 def _check_issubclass(klass: Any, check_type: type) -> bool:
     # If a hint is Annotated, we want to unwrap the underlying type and discard the rest of the
     # metadata.

--- a/src/arti/internal/utils.py
+++ b/src/arti/internal/utils.py
@@ -123,9 +123,6 @@ def import_submodules(
         }
 
 
-_int_sub = TypeVar("_int_sub", bound="_int")
-
-
 class _int(int):
     def __repr__(self) -> str:
         return f"{qname(self)}({int(self)})"

--- a/src/arti/partitions/__init__.py
+++ b/src/arti/partitions/__init__.py
@@ -5,7 +5,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 import abc
 from datetime import date
 from inspect import getattr_static
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Optional
 
 from arti.fingerprints import Fingerprint
 from arti.internal.models import Model
@@ -154,4 +154,4 @@ class NullKey(PartitionKey):
         return super().from_key_components(**key_components)
 
 
-InputFingerprints = frozendict[CompositeKey, Fingerprint]
+InputFingerprints = frozendict[CompositeKey, Optional[Fingerprint]]

--- a/src/arti/producers/__init__.py
+++ b/src/arti/producers/__init__.py
@@ -327,7 +327,7 @@ class Producer(Model):
         return Fingerprint.from_string(self._class_key_).combine(
             self.version.fingerprint,
             *(
-                partition.content_fingerprint
+                partition.get_or_compute_content_fingerprint()
                 for name, partitions in dependency_partitions.items()
                 for partition in partitions
             ),

--- a/src/arti/storage/_internal.py
+++ b/src/arti/storage/_internal.py
@@ -127,13 +127,13 @@ def extract_placeholders(
     parser: parse.Parser,
     path: str,
     spec: str,
-) -> Optional[tuple[Fingerprint, CompositeKey]]:
+) -> Optional[tuple[Optional[Fingerprint], CompositeKey]]:
     parsed_value = parser.parse(path)
     if parsed_value is None:
         if error_on_no_match:
             raise ValueError(f"Unable to parse '{path}' with '{spec}'.")
         return None
-    input_fingerprint = Fingerprint.empty()
+    input_fingerprint: Optional[Fingerprint] = None
     key_components = defaultdict[str, dict[str, str]](dict)
     for k, v in parsed_value.named.items():
         if k == "input_fingerprint":
@@ -163,7 +163,7 @@ def parse_spec(
     input_fingerprints: InputFingerprints = InputFingerprints(),
     key_types: Mapping[str, type[PartitionKey]],
     spec: str,
-) -> Mapping[str, tuple[Fingerprint, CompositeKey]]:
+) -> Mapping[str, tuple[Optional[Fingerprint], CompositeKey]]:
     parser = parse.compile(spec, case_sensitive=True)
     path_placeholders = (
         (path, placeholders)
@@ -178,5 +178,5 @@ def parse_spec(
     return {
         path: (input_fingerprint, keys)
         for (path, (input_fingerprint, keys)) in path_placeholders
-        if input_fingerprints.get(keys, Fingerprint.empty()) == input_fingerprint
+        if input_fingerprints.get(keys, None) == input_fingerprint
     }

--- a/src/arti/storage/literal.py
+++ b/src/arti/storage/literal.py
@@ -41,7 +41,5 @@ class StringLiteral(Storage[StringLiteralPartition]):
             return ()
         return tuple(
             self.generate_partition(input_fingerprint=input_fingerprint, keys=keys)
-            for keys, input_fingerprint in (
-                input_fingerprints or {CompositeKey(): Fingerprint.empty()}
-            ).items()
+            for keys, input_fingerprint in (input_fingerprints or {CompositeKey(): None}).items()
         )

--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -65,7 +65,7 @@ def test_Graph_copy(graph: Graph) -> None:
         assert graph.artifacts == copy.artifacts
         assert graph.fingerprint == copy.fingerprint
         assert hash(graph) == hash(copy)
-        assert hash(copy) == copy.fingerprint.key
+        assert hash(copy) == copy.fingerprint
 
 
 def test_Graph_literals(tmp_path: Path) -> None:
@@ -387,8 +387,8 @@ def test_Graph_read_write(tmp_path: Path) -> None:
     # Test write
     storage_partition = g.write(5, artifact=i)
     assert isinstance(storage_partition, LocalFilePartition)
-    assert storage_partition.content_fingerprint != Fingerprint.empty()
-    assert storage_partition.input_fingerprint == Fingerprint.empty()
+    assert storage_partition.content_fingerprint is not None
+    assert storage_partition.input_fingerprint is None
     assert storage_partition.keys == CompositeKey()
     assert storage_partition.path.endswith(i.format.extension)
 

--- a/tests/arti/internal/test_models.py
+++ b/tests/arti/internal/test_models.py
@@ -102,7 +102,7 @@ def test_Model_fingerprint() -> None:
         b: set[str]
 
     assert B(a=a, b={"b"}).fingerprint == Fingerprint.from_string(
-        f'B:{{"a": {a.fingerprint.key}, "b": ["b"]}}'
+        f'B:{{"a": {a.fingerprint}, "b": ["b"]}}'
     )
 
     class Excludes(A):

--- a/tests/arti/io/test_gcs_io.py
+++ b/tests/arti/io/test_gcs_io.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 import pytest
 
-from arti import CompositeKey, Fingerprint, Format, StoragePartition, StoragePartitions, View, io
+from arti import CompositeKey, Format, StoragePartition, StoragePartitions, View, io
 from arti.formats.json import JSON
 from arti.formats.pickle import Pickle
 from arti.partitions import Int64Key
@@ -40,7 +40,7 @@ def test_gcsfile_io_partitioned(gcs_bucket: str, format: Format) -> None:
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
             keys=CompositeKey(i=Int64Key(key=i)),
-            input_fingerprint=Fingerprint.empty(),
+            input_fingerprint=None,
             with_content_fingerprint=False,
         ): {"i": i}
         for i in [1, 2]

--- a/tests/arti/io/test_localfile_io.py
+++ b/tests/arti/io/test_localfile_io.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 import pytest
 
-from arti import CompositeKey, Fingerprint, Format, StoragePartition, StoragePartitions, View, io
+from arti import CompositeKey, Format, StoragePartition, StoragePartitions, View, io
 from arti.formats.json import JSON
 from arti.formats.pickle import Pickle
 from arti.partitions import Int64Key
@@ -41,7 +41,7 @@ def test_localfile_io_partitioned(tmp_path: Path, format: Format) -> None:
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
             keys=CompositeKey(i=Int64Key(key=i)),
-            input_fingerprint=Fingerprint.empty(),
+            input_fingerprint=None,
             with_content_fingerprint=False,
         ): {"i": i}
         for i in [1, 2]

--- a/tests/arti/producers/test_producer.py
+++ b/tests/arti/producers/test_producer.py
@@ -198,7 +198,7 @@ def test_Producer_string_annotation() -> None:
 def test_Producer_fingerprint() -> None:
     p1 = P1(a1=A1())
     assert p1.fingerprint == Fingerprint.from_string(
-        f'P1:{{"a1": {p1.a1.fingerprint.key}, "version": {p1.version.fingerprint.key}}}'
+        f'P1:{{"a1": {p1.a1.fingerprint}, "version": {p1.version.fingerprint}}}'
     )
 
 
@@ -214,7 +214,7 @@ def test_Producer_compute_input_fingerprint() -> None:
     assert p1.compute_input_fingerprint(
         frozendict(a1=StoragePartitions([storage_partition]))
     ) == Fingerprint.from_string(p1._class_key_).combine(
-        p1.version.fingerprint, storage_partition.content_fingerprint
+        p1.version.fingerprint, storage_partition.get_or_compute_content_fingerprint()
     )
 
     with pytest.raises(

--- a/tests/arti/storage/test_local_storage.py
+++ b/tests/arti/storage/test_local_storage.py
@@ -42,9 +42,7 @@ def test_local_partitioning(tmp_path: Path, date_keys: list[CompositeKey]) -> No
         ._visit_type(Collection(element=Struct(fields={"date": Date()}), partition_by=("date",)))
         ._visit_format(DummyFormat())
     )
-    generate_partition_files(
-        storage, InputFingerprints(zip(date_keys, repeat(Fingerprint.empty())))
-    )
+    generate_partition_files(storage, InputFingerprints(zip(date_keys, repeat(None))))
     partitions = storage.discover_partitions()
     assert len(partitions) > 0
     for partition in partitions:
@@ -73,9 +71,7 @@ def test_local_partitioning_filtered(tmp_path: Path, date_keys: list[CompositeKe
             ._visit_format(DummyFormat())
         )
         # Generate files for *all* years - we want discover_partitions to do the filtering.
-        generate_partition_files(
-            storage, InputFingerprints(zip(date_keys, repeat(Fingerprint.empty())))
-        )
+        generate_partition_files(storage, InputFingerprints(zip(date_keys, repeat(None))))
         partitions = storage.discover_partitions()
         assert len(partitions) > 0
         for partition in partitions:

--- a/tests/arti/storage/test_storage_internal.py
+++ b/tests/arti/storage/test_storage_internal.py
@@ -39,9 +39,9 @@ def paths() -> set[str]:
 @pytest.fixture()
 def paths_to_placeholders() -> PathPlaceholders:
     return {
-        "/p/1/0x1": (Fingerprint.empty(), frozendict({"x": Int8Key(key=1), "y": Int8Key(key=1)})),
-        "/p/2/0x2": (Fingerprint.empty(), frozendict({"x": Int8Key(key=2), "y": Int8Key(key=2)})),
-        "/p/3/0x3": (Fingerprint.empty(), frozendict({"x": Int8Key(key=3), "y": Int8Key(key=3)})),
+        "/p/1/0x1": (None, frozendict({"x": Int8Key(key=1), "y": Int8Key(key=1)})),
+        "/p/2/0x2": (None, frozendict({"x": Int8Key(key=2), "y": Int8Key(key=2)})),
+        "/p/3/0x3": (None, frozendict({"x": Int8Key(key=3), "y": Int8Key(key=3)})),
     }
 
 

--- a/tests/arti/test_fingerprints.py
+++ b/tests/arti/test_fingerprints.py
@@ -7,16 +7,11 @@ from arti.internal.utils import int64, uint64
 
 
 def test_Fingerprint() -> None:
-    assert Fingerprint(key=int64(5)).key == 5
-    assert Fingerprint.empty().key is None
+    assert Fingerprint(5) == 5
     assert Fingerprint.from_int(-5) == -5
-    assert Fingerprint.from_int(None) == Fingerprint.empty()
-    assert Fingerprint.from_int64(None) == Fingerprint.empty()
     assert Fingerprint.from_int64(int64(-5)) == -5
     assert Fingerprint.from_string("OK") == -7962813320811223369
     assert Fingerprint.from_string("ok") == 5227454011934222951
-    assert Fingerprint.from_string(None) == Fingerprint.empty()
-    assert Fingerprint.from_uint64(None) == Fingerprint.empty()
     assert Fingerprint.from_uint64(uint64(5)) == 5
     assert Fingerprint.from_uint64(uint64(int64(-5))) == -5
     assert Fingerprint.identity() == 0
@@ -24,22 +19,15 @@ def test_Fingerprint() -> None:
     with pytest.raises(ValueError, match="is too large for int64"):
         Fingerprint.from_int(uint64._max)
 
-    f1, f2 = Fingerprint(key=int64(1)), Fingerprint(key=int64(2))
-    assert f1 != "1"
+    f1, f2 = Fingerprint(1), Fingerprint(2)
+    assert f1 != "1"  # type: ignore[comparison-overlap]
     assert f1 != f2
-    assert not f1.is_empty
     assert not f1.is_identity
-    assert Fingerprint.empty().is_empty
     assert Fingerprint.identity().is_identity
-    assert not Fingerprint.empty().is_identity
-    assert not Fingerprint.identity().is_empty
-
-    with pytest.warns(match="returns itself"):
-        assert f1.fingerprint is f1
 
 
 def test_Fingerprint_math() -> None:
-    f1, f2, f3, f4, f5 = (Fingerprint(key=int64(i)) for i in range(5))
+    f1, f2, f3, f4, f5 = (Fingerprint(i) for i in range(5))
     # associative
     assert f1.combine(f2.combine(f3)) == f3.combine(f1.combine(f2))
     # commutative
@@ -51,9 +39,6 @@ def test_Fingerprint_math() -> None:
     assert f1.combine(Fingerprint.identity()) == f1
     # self-inverse
     assert f1.combine(f1) == 0
-    # empty cascades
-    assert Fingerprint.empty().combine(f1).is_empty
-    assert f1.combine(Fingerprint.empty()).is_empty
     # bitwise operators
     assert f2 & 15 == 1
     assert f2 << 15 == 32768

--- a/tests/arti/versions/test_version.py
+++ b/tests/arti/versions/test_version.py
@@ -55,7 +55,7 @@ def test_Timestamp() -> None:
     d = datetime.now(tz=timezone.utc)
     assert Timestamp(dt=d).fingerprint == round(d.timestamp())
     # Check the default is ~now.
-    key, now = Timestamp().fingerprint.key, round(datetime.now(tz=timezone.utc).timestamp())
+    key, now = Timestamp().fingerprint, round(datetime.now(tz=timezone.utc).timestamp())
     assert key is not None
     assert now - 1 <= key <= now + 1
     # Confirm naive datetime are not supported


### PR DESCRIPTION
# Description

Fingerprints are mostly used as ints and should be serialized as a scalar field, not a separate model. Additionally, having the `Fingerprint.empty()` I think was a bit off and masked places we didn't properly handle what should have really been `Optional[...]`. This changes to be an int subclass and updates places to use `Optional[Fingerprint]` when appropriate.

One area in particular that could be improved is changing StoragePartition to have a _required_ `content_fingerprint` as a separate model (or something), which would ensure we're passing the appropriate data around instead of having to call `compute_content_fingerprint` within the Executor, Backend, etc (at which points, they should already be computed, but we couldn't be sure typing wise).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
