### PR TITLE
Rename PartitionKey->PartitionField and CompositeKeys->PartitionKey

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ extend-select = [
     # "PTH",  # TODO: prefer pathlib.Path over os.path ops
 ]
 ignore = [
-    "B008",   # don't call function in arg defaults (eg: InputFingerprint or CompositeKey)
+    "B008",   # don't call function in arg defaults (eg: InputFingerprint or PartitionKey)
     "E501",   # line too long (covered by black)
     "PT012",  # `pytest.raises()` block should contain a single simple statement
     "RET505", # Unnecessary `else` after `return` statement

--- a/src/arti/__init__.py
+++ b/src/arti/__init__.py
@@ -16,7 +16,7 @@ from arti.fingerprints import Fingerprint
 from arti.formats import Format
 from arti.graphs import Graph, GraphSnapshot
 from arti.io import read, register_reader, register_writer, write
-from arti.partitions import CompositeKey, CompositeKeyTypes, InputFingerprints, PartitionKey
+from arti.partitions import InputFingerprints, PartitionField, PartitionKey, PartitionKeyTypes
 from arti.producers import PartitionDependencies, Producer, producer
 from arti.statistics import Statistic
 from arti.storage import Storage, StoragePartition, StoragePartitions
@@ -31,8 +31,6 @@ __all__ = [
     "Artifact",
     "Backend",
     "BackendConnection",
-    "CompositeKey",
-    "CompositeKeyTypes",
     "Executor",
     "Fingerprint",
     "Format",
@@ -40,7 +38,9 @@ __all__ = [
     "GraphSnapshot",
     "InputFingerprints",
     "PartitionDependencies",
+    "PartitionField",
     "PartitionKey",
+    "PartitionKeyTypes",
     "Producer",
     "Statistic",
     "Storage",

--- a/src/arti/executors/__init__.py
+++ b/src/arti/executors/__init__.py
@@ -11,7 +11,7 @@ from arti.fingerprints import Fingerprint
 from arti.graphs import GraphSnapshot
 from arti.internal.models import Model
 from arti.internal.utils import frozendict
-from arti.partitions import CompositeKey, InputFingerprints
+from arti.partitions import InputFingerprints, PartitionKey
 from arti.producers import InputPartitions, Producer
 from arti.storage import StoragePartitions
 
@@ -40,7 +40,7 @@ class Executor(Model):
         producer: Producer,
         *,
         partition_input_fingerprints: InputFingerprints,
-    ) -> set[CompositeKey]:
+    ) -> set[PartitionKey]:
         # NOTE: The output partitions may be built, but not yet associated with this GraphSnapshot
         # (eg: raw input data changed, but no changes trickled into this specific Producer). Hence
         # we'll fetch all StoragePartitions for each Storage, filtered to the PKs and
@@ -66,10 +66,10 @@ class Executor(Model):
         connection: BackendConnection,
         producer: Producer,
         *,
-        existing_partition_keys: set[CompositeKey],
+        existing_partition_keys: set[PartitionKey],
         input_fingerprint: Fingerprint,
         partition_dependencies: frozendict[str, StoragePartitions],
-        partition_key: CompositeKey,
+        partition_key: PartitionKey,
     ) -> None:
         # TODO: Should this "skip if exists" live here or higher up?
         if partition_key in existing_partition_keys:

--- a/src/arti/graphs/__init__.py
+++ b/src/arti/graphs/__init__.py
@@ -18,7 +18,7 @@ from arti.backends import Backend, BackendConnection
 from arti.fingerprints import Fingerprint
 from arti.internal.models import Model
 from arti.internal.utils import TypedBox, frozendict
-from arti.partitions import CompositeKey
+from arti.partitions import PartitionKey
 from arti.producers import Producer
 from arti.storage import StoragePartition, StoragePartitions
 from arti.types import is_partitioned
@@ -249,7 +249,7 @@ class Graph(Model):
         *,
         artifact: Artifact,
         input_fingerprint: Optional[Fingerprint] = None,
-        keys: CompositeKey = CompositeKey(),
+        keys: PartitionKey = PartitionKey(),
         view: Optional[View] = None,
         snapshot: Optional[GraphSnapshot] = None,
         connection: Optional[BackendConnection] = None,
@@ -405,7 +405,7 @@ class GraphSnapshot(Model):
         *,
         artifact: Artifact,
         input_fingerprint: Optional[Fingerprint] = None,
-        keys: CompositeKey = CompositeKey(),
+        keys: PartitionKey = PartitionKey(),
         view: Optional[View] = None,
         connection: Optional[BackendConnection] = None,
     ) -> StoragePartition:

--- a/src/arti/producers/__init__.py
+++ b/src/arti/producers/__init__.py
@@ -32,7 +32,7 @@ from arti.internal.type_hints import (
     signature,
 )
 from arti.internal.utils import frozendict, get_module_name, ordinal
-from arti.partitions import CompositeKey, InputFingerprints, NotPartitioned, PartitionKey
+from arti.partitions import InputFingerprints, NotPartitioned, PartitionKey
 from arti.storage import StoragePartitions
 from arti.types import is_partitioned
 from arti.versions import SemVer, Version
@@ -46,7 +46,7 @@ BuildInputs = frozendict[str, View]
 Outputs = tuple[View, ...]
 
 InputPartitions = frozendict[str, StoragePartitions]
-PartitionDependencies = frozendict[CompositeKey, InputPartitions]
+PartitionDependencies = frozendict[PartitionKey, InputPartitions]
 MapSig = Callable[..., PartitionDependencies]
 BuildSig = Callable[..., Any]
 ValidateSig = Callable[..., tuple[bool, str]]
@@ -348,8 +348,8 @@ class Producer(Model):
         )
         partition_input_fingerprints = InputFingerprints(
             {
-                composite_key: self.compute_input_fingerprint(dependency_partitions)
-                for composite_key, dependency_partitions in partition_dependencies.items()
+                partition_key: self.compute_input_fingerprint(dependency_partitions)
+                for partition_key, dependency_partitions in partition_dependencies.items()
             }
         )
         return partition_dependencies, partition_input_fingerprints

--- a/src/arti/storage/literal.py
+++ b/src/arti/storage/literal.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 from arti.fingerprints import Fingerprint
-from arti.partitions import CompositeKey, InputFingerprints
+from arti.partitions import InputFingerprints, PartitionKey
 from arti.storage import Storage, StoragePartition
 
 _not_written_err = FileNotFoundError("Literal has not been written yet")
@@ -41,5 +41,5 @@ class StringLiteral(Storage[StringLiteralPartition]):
             return ()
         return tuple(
             self.generate_partition(input_fingerprint=input_fingerprint, keys=keys)
-            for keys, input_fingerprint in (input_fingerprints or {CompositeKey(): None}).items()
+            for keys, input_fingerprint in (input_fingerprints or {PartitionKey(): None}).items()
         )

--- a/src/arti/types/bigquery.py
+++ b/src/arti/types/bigquery.py
@@ -256,7 +256,7 @@ class TableTypeAdapter(TypeAdapter):
         if partition:
             # BigQuery only supports a single partitioning field. We'll move the rest to the
             # beginning of the cluster_by. This shouldn't matter much anyway since, depending on the
-            # Storage, we'll have separate tables for each unique composite key.
+            # Storage, we'll have separate tables for each unique partition field.
             head, *tail = partition
             if tail:
                 cluster = (*tail, *cluster)

--- a/tests/arti/dummies.py
+++ b/tests/arti/dummies.py
@@ -6,10 +6,10 @@ from typing import Annotated, Any
 from arti import (
     Annotation,
     Artifact,
-    CompositeKeyTypes,
     Fingerprint,
     Format,
     InputFingerprints,
+    PartitionKeyTypes,
     Producer,
     Statistic,
     Storage,
@@ -60,7 +60,7 @@ class DummyStorage(Storage[DummyPartition]):
     def discover_partitions(
         self, input_fingerprints: InputFingerprints = InputFingerprints()
     ) -> tuple[DummyPartition, ...]:
-        if self.key_types != CompositeKeyTypes():
+        if self.key_types != PartitionKeyTypes():
             raise NotImplementedError()
         if input_fingerprints is not None and input_fingerprints != InputFingerprints():
             raise NotImplementedError()

--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -7,7 +7,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from box import BoxError
 
-from arti import Artifact, CompositeKey, Fingerprint, Graph, GraphSnapshot, View, producer
+from arti import Artifact, Fingerprint, Graph, GraphSnapshot, PartitionKey, View, producer
 from arti.backends.memory import MemoryBackend
 from arti.executors.local import LocalExecutor
 from arti.graphs import ArtifactBox
@@ -389,7 +389,7 @@ def test_Graph_read_write(tmp_path: Path) -> None:
     assert isinstance(storage_partition, LocalFilePartition)
     assert storage_partition.content_fingerprint is not None
     assert storage_partition.input_fingerprint is None
-    assert storage_partition.keys == CompositeKey()
+    assert storage_partition.keys == PartitionKey()
     assert storage_partition.path.endswith(i.format.extension)
 
     # Once snapshotted, writing to the raw Artifacts would result in a different snapshot.

--- a/tests/arti/io/test_gcs_io.py
+++ b/tests/arti/io/test_gcs_io.py
@@ -2,10 +2,10 @@ from typing import Annotated
 
 import pytest
 
-from arti import CompositeKey, Format, StoragePartition, StoragePartitions, View, io
+from arti import Format, PartitionKey, StoragePartition, StoragePartitions, View, io
 from arti.formats.json import JSON
 from arti.formats.pickle import Pickle
-from arti.partitions import Int64Key
+from arti.partitions import Int64Field
 from arti.storage.google.cloud.storage import GCSFile
 from arti.types import Collection, Int64, Struct
 from tests.arti.dummies import Num
@@ -39,7 +39,7 @@ def test_gcsfile_io_partitioned(gcs_bucket: str, format: Format) -> None:
     a = PartitionedNum(format=format, storage=GCSFile(bucket=gcs_bucket, path="{i.key}"))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
-            keys=CompositeKey(i=Int64Key(key=i)),
+            keys=PartitionKey(i=Int64Field(key=i)),
             input_fingerprint=None,
             with_content_fingerprint=False,
         ): {"i": i}

--- a/tests/arti/io/test_localfile_io.py
+++ b/tests/arti/io/test_localfile_io.py
@@ -3,10 +3,10 @@ from typing import Annotated
 
 import pytest
 
-from arti import CompositeKey, Format, StoragePartition, StoragePartitions, View, io
+from arti import Format, PartitionKey, StoragePartition, StoragePartitions, View, io
 from arti.formats.json import JSON
 from arti.formats.pickle import Pickle
-from arti.partitions import Int64Key
+from arti.partitions import Int64Field
 from arti.storage.local import LocalFile
 from arti.types import Collection, Int64, Struct
 from tests.arti.dummies import Num
@@ -40,7 +40,7 @@ def test_localfile_io_partitioned(tmp_path: Path, format: Format) -> None:
     a = PartitionedNum(format=format, storage=LocalFile(path=str(tmp_path / "{i.key}")))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
-            keys=CompositeKey(i=Int64Key(key=i)),
+            keys=PartitionKey(i=Int64Field(key=i)),
             input_fingerprint=None,
             with_content_fingerprint=False,
         ): {"i": i}

--- a/tests/arti/partitions/test_partitions.py
+++ b/tests/arti/partitions/test_partitions.py
@@ -4,54 +4,49 @@ from typing import ClassVar
 
 import pytest
 
-from arti import PartitionKey, Type
+from arti import PartitionField, Type
 from arti.internal.utils import frozendict
 from arti.partitions import (
-    DateKey,
-    Int8Key,
-    Int16Key,
-    Int32Key,
-    Int64Key,
-    NullKey,
-    _IntKey,
-    key_component,
+    DateField,
+    Int8Field,
+    Int16Field,
+    Int32Field,
+    Int64Field,
+    NullField,
+    PartitionKey,
+    _IntField,
+    field_component,
 )
 from arti.types import Collection, Date, Int8, Int16, Int32, Int64, Struct
 
 
-def test_PartitionKey_key_components() -> None:
-    components = PartitionKey.key_components
+def test_PartitionField_components() -> None:
+    components = PartitionField.components
     assert isinstance(components, frozenset)
     assert components == frozenset()
 
-    components = Int8Key.key_components
+    components = Int8Field.components
     assert isinstance(components, frozenset)
     assert components == {"key", "hex"}
 
-    assert isinstance(Int8Key.hex, key_component)
-    assert isinstance(Int8Key.hex, property)
+    assert isinstance(Int8Field.hex, field_component)
+    assert isinstance(Int8Field.hex, property)
 
 
-def test_PartitionKey_lookup_from_type() -> None:
-    assert PartitionKey.get_class_for(Int8()) is Int8Key
-    assert PartitionKey.get_class_for(Int16()) is Int16Key
-    assert PartitionKey.get_class_for(Date()) is DateKey
-
-    assert PartitionKey.types_from(Int8()) == frozendict()
-    assert PartitionKey.types_from(Struct(fields={"date": Date(), "i": Int8()})) == frozendict()
-    assert PartitionKey.types_from(
-        Collection(element=Struct(fields={"date": Date(), "i": Int8()}), partition_by=("date", "i"))
-    ) == frozendict({"date": DateKey, "i": Int8Key})
+def test_PartitionField_get_class_for() -> None:
+    assert PartitionField.get_class_for(Int8()) is Int8Field
+    assert PartitionField.get_class_for(Int16()) is Int16Field
+    assert PartitionField.get_class_for(Date()) is DateField
 
 
-def test_PartitionKey_subclass() -> None:
-    class AbstractKey(PartitionKey):
+def test_PartitionField_subclass() -> None:
+    class AbstractKey(PartitionField):
         _abstract_ = True
-        _by_type_: ClassVar[dict[type[Type], type[PartitionKey]]] = {}
+        _by_type_: ClassVar[dict[type[Type], type[PartitionField]]] = {}
 
         key: int
 
-    with pytest.raises(TypeError, match="NoDefaultKey must set `default_key_components`"):
+    with pytest.raises(TypeError, match="NoDefaultKey must set `default_components`"):
 
         class NoDefaultKey(AbstractKey):
             pass
@@ -59,79 +54,85 @@ def test_PartitionKey_subclass() -> None:
     with pytest.raises(TypeError, match="NoMatchingTypeKey must set `matching_type`"):
 
         class NoMatchingTypeKey(AbstractKey):
-            default_key_components: ClassVar[frozendict[str, str]] = frozendict(key="key")
+            default_components: ClassVar[frozendict[str, str]] = frozendict(key="key")
 
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            r"Unknown key_components in UnknownDefaultKey.default_key_components: {'junk'}"
-        ),
+        match=re.escape(r"Unknown components in UnknownDefaultKey.default_components: {'junk'}"),
     ):
 
         class UnknownDefaultKey(AbstractKey):
-            default_key_components: ClassVar[frozendict[str, str]] = frozendict(junk="junk")
+            default_components: ClassVar[frozendict[str, str]] = frozendict(junk="junk")
             matching_type: ClassVar[type[Type]] = Int8
 
     class SomeKey(AbstractKey):
-        default_key_components: ClassVar[frozendict[str, str]] = frozendict(key="key")
+        default_components: ClassVar[frozendict[str, str]] = frozendict(key="key")
         matching_type: ClassVar[type[Type]] = Int8
 
     assert AbstractKey._by_type_ == {Int8: SomeKey}
-    assert SomeKey not in PartitionKey._by_type_.values()
+    assert SomeKey not in PartitionField._by_type_.values()
 
 
-def test_DateKey() -> None:
-    k = DateKey(key=date(1970, 1, 1))
+def test_DateField() -> None:
+    k = DateField(key=date(1970, 1, 1))
     assert k.Y == 1970
     assert k.m == 1
     assert k.d == 1
     assert k.iso == "1970-01-01"
 
-    assert k == DateKey.from_key_components(Y="1970", m="1", d="1")
-    assert k == DateKey.from_key_components(Y="1970", m="01", d="01")
-    assert k == DateKey.from_key_components(iso="1970-01-01")
-    assert k == DateKey.from_key_components(key="1970-01-01")
+    assert k == DateField.from_components(Y="1970", m="1", d="1")
+    assert k == DateField.from_components(Y="1970", m="01", d="01")
+    assert k == DateField.from_components(iso="1970-01-01")
+    assert k == DateField.from_components(key="1970-01-01")
     with pytest.raises(
         NotImplementedError,
-        match=re.escape("Unable to parse 'DateKey' from: {'junk': 'abc'}"),
+        match=re.escape("Unable to parse 'DateField' from: {'junk': 'abc'}"),
     ):
-        DateKey.from_key_components(junk="abc")
+        DateField.from_components(junk="abc")
 
 
 @pytest.mark.parametrize(
     ("IntKey", "matching_type"),
     [
-        (Int8Key, Int8),
-        (Int16Key, Int16),
-        (Int32Key, Int32),
-        (Int64Key, Int64),
+        (Int8Field, Int8),
+        (Int16Field, Int16),
+        (Int32Field, Int32),
+        (Int64Field, Int64),
     ],
 )
-def test_IntKeys(IntKey: type[_IntKey], matching_type: type[Type]) -> None:
+def test_IntFields(IntKey: type[_IntField], matching_type: type[Type]) -> None:
     assert IntKey.matching_type is matching_type
 
     k = IntKey(key=1)
     assert k.hex == "0x1"
 
-    assert k == IntKey.from_key_components(key="1")
-    assert k == IntKey.from_key_components(hex="0x1")
+    assert k == IntKey.from_components(key="1")
+    assert k == IntKey.from_components(hex="0x1")
 
     with pytest.raises(
         NotImplementedError,
         match=re.escape(f"Unable to parse '{IntKey.__name__}' from: {{'junk': 'abc'}}"),
     ):
-        IntKey.from_key_components(junk="abc")
+        IntKey.from_components(junk="abc")
 
 
-def test_NullKey() -> None:
-    k = NullKey()
+def test_NullField() -> None:
+    k = NullField()
     assert k.key is None
 
-    assert k == NullKey.from_key_components(key="None")
+    assert k == NullField.from_components(key="None")
 
     with pytest.raises(
-        NotImplementedError, match=re.escape("Unable to parse 'NullKey' from: {'junk': 'abc'}")
+        NotImplementedError, match=re.escape("Unable to parse 'NullField' from: {'junk': 'abc'}")
     ):
-        NullKey.from_key_components(junk="abc")
-    with pytest.raises(ValueError, match="'NullKey' can only be used with 'None'!"):
-        NullKey.from_key_components(key="abc")
+        NullField.from_components(junk="abc")
+    with pytest.raises(ValueError, match="'NullField' can only be used with 'None'!"):
+        NullField.from_components(key="abc")
+
+
+def test_PartitionKey_types_frome() -> None:
+    assert PartitionKey.types_from(Int8()) == frozendict()
+    assert PartitionKey.types_from(Struct(fields={"date": Date(), "i": Int8()})) == frozendict()
+    assert PartitionKey.types_from(
+        Collection(element=Struct(fields={"date": Date(), "i": Int8()}), partition_by=("date", "i"))
+    ) == frozendict({"date": DateField, "i": Int8Field})

--- a/tests/arti/partitions/test_partitions.py
+++ b/tests/arti/partitions/test_partitions.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 import pytest
 
-from arti import PartitionField, Type
+from arti import PartitionField, PartitionKey, Type
 from arti.internal.utils import frozendict
 from arti.partitions import (
     DateField,
@@ -13,7 +13,6 @@ from arti.partitions import (
     Int32Field,
     Int64Field,
     NullField,
-    PartitionKey,
     _IntField,
     field_component,
 )

--- a/tests/arti/storage/test_gcs_storage.py
+++ b/tests/arti/storage/test_gcs_storage.py
@@ -3,8 +3,8 @@ import hashlib
 
 from gcsfs import GCSFileSystem
 
-from arti import CompositeKey, Fingerprint
-from arti.partitions import Int32Key
+from arti import Fingerprint, PartitionKey
+from arti.partitions import Int32Field
 from arti.storage.google.cloud.storage import GCSFile
 from arti.types import Collection, Int32, Struct
 from tests.arti.dummies import DummyFormat
@@ -24,7 +24,7 @@ def test_GCSFile_discover_partitions(gcs: GCSFileSystem, gcs_bucket: str) -> Non
         ._visit_type(Collection(element=Struct(fields={"i": Int32()}), partition_by=("i",)))
         ._visit_format(DummyFormat())
     )
-    expected_keys = {CompositeKey(i=Int32Key(key=i)) for i in [0, 1]}
+    expected_keys = {PartitionKey(i=Int32Field(key=i)) for i in [0, 1]}
     gcs.pipe({storage.qualified_path.format(**keys): b"data" for keys in expected_keys})
     for partition in storage.discover_partitions():
         assert partition.keys in expected_keys

--- a/tests/arti/storage/test_literal_storage.py
+++ b/tests/arti/storage/test_literal_storage.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from arti import CompositeKey, Fingerprint, InputFingerprints
+from arti import Fingerprint, InputFingerprints, PartitionKey
 from arti.storage.literal import StringLiteral, StringLiteralPartition
 from arti.types import Collection, Int64, Struct
 from tests.arti.dummies import DummyFormat
@@ -40,7 +40,7 @@ def test_StringLiteral_errors() -> None:
         ),
     ):
         StringLiteral(value="test")._visit_type(Int64()).discover_partitions(
-            input_fingerprints=InputFingerprints({CompositeKey(): Fingerprint.from_int(5)}),
+            input_fingerprints=InputFingerprints({PartitionKey(): Fingerprint.from_int(5)}),
         )
     with pytest.raises(
         ValueError,

--- a/tests/arti/storage/test_local_storage.py
+++ b/tests/arti/storage/test_local_storage.py
@@ -6,22 +6,22 @@ from pathlib import Path
 
 import pytest
 
-from arti import CompositeKey, Fingerprint, InputFingerprints
-from arti.partitions import DateKey
+from arti import Fingerprint, InputFingerprints, PartitionKey
+from arti.partitions import DateField
 from arti.storage.local import LocalFile, LocalFilePartition
 from arti.types import Collection, Date, Struct
 from tests.arti.dummies import DummyFormat
 
 
 @pytest.fixture()
-def date_keys() -> list[CompositeKey]:
+def date_keys() -> list[PartitionKey]:
     return [
-        CompositeKey(date=date_key)
+        PartitionKey(date=date_key)
         for date_key in (
-            DateKey(key=date(1970, 1, 1)),
-            DateKey(key=date(1970, 1, 2)),
-            DateKey(key=date(1970, 1, 3)),
-            DateKey(key=date(2021, 1, 1)),
+            DateField(key=date(1970, 1, 1)),
+            DateField(key=date(1970, 1, 2)),
+            DateField(key=date(1970, 1, 3)),
+            DateField(key=date(2021, 1, 1)),
         )
     ]
 
@@ -36,7 +36,7 @@ def generate_partition_files(storage: LocalFile, input_fingerprints: InputFinger
         partition_path.touch()
 
 
-def test_local_partitioning(tmp_path: Path, date_keys: list[CompositeKey]) -> None:
+def test_local_partitioning(tmp_path: Path, date_keys: list[PartitionKey]) -> None:
     storage = (
         LocalFile(path=str(tmp_path / "{date.Y}" / "{date.m}" / "{date.d}" / "test"))
         ._visit_type(Collection(element=Struct(fields={"date": Date()}), partition_by=("date",)))
@@ -49,10 +49,10 @@ def test_local_partitioning(tmp_path: Path, date_keys: list[CompositeKey]) -> No
         assert isinstance(partition, LocalFilePartition)
         assert set(partition.keys) == {"date"}
         assert partition.keys in date_keys
-        assert isinstance(partition.keys["date"], DateKey)
+        assert isinstance(partition.keys["date"], DateField)
 
 
-def test_local_partitioning_filtered(tmp_path: Path, date_keys: list[CompositeKey]) -> None:
+def test_local_partitioning_filtered(tmp_path: Path, date_keys: list[PartitionKey]) -> None:
     for year in {k["date"].Y for k in date_keys}:  # type: ignore[attr-defined]
         storage = (
             LocalFile(
@@ -78,12 +78,12 @@ def test_local_partitioning_filtered(tmp_path: Path, date_keys: list[CompositeKe
             assert isinstance(partition, LocalFilePartition)
             assert set(partition.keys) == {"date"}
             assert partition.keys in date_keys
-            assert isinstance(partition.keys["date"], DateKey)
+            assert isinstance(partition.keys["date"], DateField)
             assert year == partition.keys["date"].Y
 
 
 def test_local_partitioning_with_input_fingerprints(
-    tmp_path: Path, date_keys: list[CompositeKey]
+    tmp_path: Path, date_keys: list[PartitionKey]
 ) -> None:
     storage = (
         LocalFile(
@@ -103,7 +103,7 @@ def test_local_partitioning_with_input_fingerprints(
         assert isinstance(partition, LocalFilePartition)
         assert set(partition.keys) == {"date"}
         assert partition.keys in date_keys
-        assert isinstance(partition.keys["date"], DateKey)
+        assert isinstance(partition.keys["date"], DateField)
         assert partition.input_fingerprint == input_fingerprint
 
 


### PR DESCRIPTION
# Description

The name `CompositeKey` was always confusing and in reality was actually the full "partition key". The old `PartitionKey` was really the info for a single field, so has been renamed to `PartitionField`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
