### PR TITLE
Ungroup dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,21 +1,13 @@
 version: 2
 
 updates:
-- package-ecosystem: pip
-  directory: /
-  groups:
-    deps:
-      patterns:
-        - "*"
-  schedule:
-    interval: weekly
-    day: "monday"
-- package-ecosystem: github-actions
-  directory: /
-  groups:
-    deps:
-      patterns:
-        - "*"
-  schedule:
-    interval: weekly
-    day: "monday"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: "monday"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: "monday"


### PR DESCRIPTION
# Description

Reverses https://github.com/artigraph/artigraph/pull/422 - I haven't had time to update to pydantic v2 yet (which breaks things), but don't need to block other upgrades in the meantime.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
