### PR TITLE
Add StoragePartitionSnapshot to disambiguate fingerprinted partitions

### DIFF
--- a/src/arti/__init__.py
+++ b/src/arti/__init__.py
@@ -18,7 +18,13 @@ from arti.io import read, register_reader, register_writer, write
 from arti.partitions import InputFingerprints, PartitionField, PartitionKey, PartitionKeyTypes
 from arti.producers import PartitionDependencies, Producer, producer
 from arti.statistics import Statistic
-from arti.storage import Storage, StoragePartition, StoragePartitions
+from arti.storage import (
+    Storage,
+    StoragePartition,
+    StoragePartitions,
+    StoragePartitionSnapshot,
+    StoragePartitionSnapshots,
+)
 from arti.thresholds import Threshold
 from arti.types import Type, TypeAdapter, TypeSystem
 from arti.versions import Version
@@ -44,6 +50,8 @@ __all__ = [
     "Statistic",
     "Storage",
     "StoragePartition",
+    "StoragePartitionSnapshot",
+    "StoragePartitionSnapshots",
     "StoragePartitions",
     "Threshold",
     "Type",

--- a/src/arti/backends/__init__.py
+++ b/src/arti/backends/__init__.py
@@ -14,7 +14,7 @@ from arti.fingerprints import Fingerprint
 from arti.internal.models import Model
 from arti.internal.type_hints import Self
 from arti.partitions import InputFingerprints
-from arti.storage import StoragePartitions
+from arti.storage import StoragePartitionSnapshots
 
 if TYPE_CHECKING:
     from arti.graphs import Graph, GraphSnapshot
@@ -39,7 +39,7 @@ class BackendConnection:
     @abstractmethod
     def read_artifact_partitions(
         self, artifact: Artifact, input_fingerprints: InputFingerprints = InputFingerprints()
-    ) -> StoragePartitions:
+    ) -> StoragePartitionSnapshots:
         """Read all known Partitions for this Storage spec.
 
         If `input_fingerprints` is provided, the returned partitions will be filtered accordingly.
@@ -50,7 +50,9 @@ class BackendConnection:
         raise NotImplementedError()
 
     @abstractmethod
-    def write_artifact_partitions(self, artifact: Artifact, partitions: StoragePartitions) -> None:
+    def write_artifact_partitions(
+        self, artifact: Artifact, partitions: StoragePartitionSnapshots
+    ) -> None:
         """Add more partitions for a Storage spec."""
         raise NotImplementedError()
 
@@ -93,7 +95,7 @@ class BackendConnection:
     @abstractmethod
     def read_snapshot_partitions(
         self, snapshot: GraphSnapshot, artifact_key: str, artifact: Artifact
-    ) -> StoragePartitions:
+    ) -> StoragePartitionSnapshots:
         """Read the known Partitions for the named Artifact in a specific GraphSnapshot."""
         raise NotImplementedError()
 
@@ -103,7 +105,7 @@ class BackendConnection:
         snapshot: GraphSnapshot,
         artifact_key: str,
         artifact: Artifact,
-        partitions: StoragePartitions,
+        partitions: StoragePartitionSnapshots,
     ) -> None:
         """Link the Partitions to the named Artifact in a specific GraphSnapshot."""
         raise NotImplementedError()
@@ -115,7 +117,7 @@ class BackendConnection:
         snapshot: GraphSnapshot,
         artifact_key: str,
         artifact: Artifact,
-        partitions: StoragePartitions,
+        partitions: StoragePartitionSnapshots,
     ) -> None:
         self.write_artifact_partitions(artifact, partitions)
         self.write_snapshot_partitions(snapshot, artifact_key, artifact, partitions)

--- a/src/arti/backends/memory.py
+++ b/src/arti/backends/memory.py
@@ -79,7 +79,7 @@ class MemoryConnection(BackendConnection):
             partitions = {
                 partition
                 for partition in partitions
-                if input_fingerprints.get(partition.keys) == partition.input_fingerprint
+                if input_fingerprints.get(partition.partition_key) == partition.input_fingerprint
             }
         return tuple(partitions)
 

--- a/src/arti/executors/__init__.py
+++ b/src/arti/executors/__init__.py
@@ -57,7 +57,8 @@ class Executor(Model):
         # TODO: Guarantee all outputs have the same set of identified partitions. Currently, this
         # pretends a partition is built for all outputs if _any_ are built for that partition.
         return {
-            partition.keys for partition in chain.from_iterable(existing_output_partitions.values())
+            partition.partition_key
+            for partition in chain.from_iterable(existing_output_partitions.values())
         }
 
     def build_producer_partition(
@@ -101,6 +102,6 @@ class Executor(Model):
                 output,
                 artifact=snapshot.graph.producer_outputs[producer][i],
                 input_fingerprint=input_fingerprint,
-                keys=partition_key,
+                partition_key=partition_key,
                 view=producer._outputs_[i],
             )

--- a/src/arti/executors/local.py
+++ b/src/arti/executors/local.py
@@ -49,7 +49,7 @@ class LocalExecutor(Executor):
                             input_fingerprint=assert_not_none(
                                 partition_input_fingerprints[partition_key]
                             ),
-                            partition_dependencies=dependencies,
+                            input_partitions=dependencies,
                             partition_key=partition_key,
                         )
                 else:

--- a/src/arti/graphs/__init__.py
+++ b/src/arti/graphs/__init__.py
@@ -249,7 +249,7 @@ class Graph(Model):
         *,
         artifact: Artifact,
         input_fingerprint: Fingerprint | None = None,
-        keys: PartitionKey = PartitionKey(),
+        partition_key: PartitionKey = PartitionKey(),
         view: View | None = None,
         snapshot: GraphSnapshot | None = None,
         connection: BackendConnection | None = None,
@@ -266,7 +266,9 @@ class Graph(Model):
         view.check_annotation_compatibility(type(data))
         view.check_artifact_compatibility(artifact)
         storage_partition = artifact.storage.generate_partition(
-            input_fingerprint=input_fingerprint, keys=keys, with_content_fingerprint=False
+            input_fingerprint=input_fingerprint,
+            partition_key=partition_key,
+            with_content_fingerprint=False,
         )
         storage_partition = io.write(
             data,
@@ -405,7 +407,7 @@ class GraphSnapshot(Model):
         *,
         artifact: Artifact,
         input_fingerprint: Fingerprint | None = None,
-        keys: PartitionKey = PartitionKey(),
+        partition_key: PartitionKey = PartitionKey(),
         view: View | None = None,
         connection: BackendConnection | None = None,
     ) -> StoragePartition:
@@ -413,7 +415,7 @@ class GraphSnapshot(Model):
             data,
             artifact=artifact,
             input_fingerprint=input_fingerprint,
-            keys=keys,
+            partition_key=partition_key,
             view=view,
             snapshot=self,
             connection=connection,

--- a/src/arti/internal/type_hints.py
+++ b/src/arti/internal/type_hints.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import date, datetime
 from types import GenericAlias, UnionType
 from typing import (
@@ -26,6 +26,12 @@ NoneType = cast(type, type(None))  # mypy otherwise treats type(None) as an obje
 def assert_not_none(v: _T | None) -> _T:
     assert v is not None
     return v
+
+
+def assert_all_instances(values: Iterable[Any], *, type: type[_T]) -> Iterable[_T]:
+    if not all(isinstance(v, type) for v in values):
+        raise TypeError(f"Expected {type.__name__} instances")
+    return values
 
 
 def _check_issubclass(klass: Any, check_type: type) -> bool:

--- a/src/arti/io/__init__.py
+++ b/src/arti/io/__init__.py
@@ -4,12 +4,17 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from collections.abc import Sequence
 from types import ModuleType
-from typing import Any, cast
+from typing import Any
 
 from arti.formats import Format
 from arti.internal.dispatch import multipledispatch
 from arti.internal.utils import import_submodules
-from arti.storage import StoragePartition, StoragePartitionVar
+from arti.storage import (
+    StoragePartition,
+    StoragePartitionSnapshot,
+    StoragePartitionSnapshots,
+    StoragePartitionVar,
+)
 from arti.types import Type, is_partitioned
 from arti.views import View
 
@@ -35,20 +40,26 @@ register_reader = _read.register
 
 
 def read(
-    type_: Type, format: Format, storage_partitions: Sequence[StoragePartition], view: View
+    type_: Type, format: Format, storage_partition_snapshots: StoragePartitionSnapshots, view: View
 ) -> Any:
-    if not storage_partitions:
+    if not storage_partition_snapshots:
         # NOTE: Aside from simplifying this check up front, multiple dispatch with unknown list
         # element type can be ambiguous/error.
         raise FileNotFoundError("No data")
-    if len(storage_partitions) > 1 and not is_partitioned(type_):
+    if len(storage_partition_snapshots) > 1 and not is_partitioned(type_):
         raise ValueError(
             f"Multiple partitions can only be read into a partitioned Collection, not {type_}"
         )
-    # TODO Checks that the returned data matches the Type/View
+    # TODO: Verify the content_fingerprints before (and/or after) reading data.
     #
-    # Likely add a View method that can handle this type + schema checking, filtering to column/row subsets if necessary, etc
-    return _read(type_, format, storage_partitions, view)
+    # TODO: Check that the returned data matches the Type/View. Likely add a View method that can
+    # handle this type + schema checking, filtering to column/row subsets if necessary, etc
+    return _read(
+        type_,
+        format,
+        tuple(snapshot.storage_partition for snapshot in storage_partition_snapshots),
+        view,
+    )
 
 
 @multipledispatch("io.write", discovery_func=_discover)
@@ -64,8 +75,8 @@ register_writer = _write.register
 
 
 def write(
-    data: Any, type_: Type, format: Format, storage_partition: StoragePartitionVar, view: View
-) -> StoragePartitionVar:
+    data: Any, type_: Type, format: Format, storage_partition: StoragePartition, view: View
+) -> StoragePartitionSnapshot:
     if (updated := _write(data, type_, format, storage_partition, view)) is not None:
-        return cast(StoragePartitionVar, updated)
-    return storage_partition
+        storage_partition = updated
+    return storage_partition.snapshot()

--- a/src/arti/io/json_stringliteral_python.py
+++ b/src/arti/io/json_stringliteral_python.py
@@ -7,14 +7,16 @@ from typing import Any
 
 from arti.formats.json import JSON
 from arti.io import register_reader, register_writer
-from arti.storage.literal import StringLiteralPartition, _not_written_err
+from arti.storage.literal import StringLiteralPartition
 from arti.types import Type, is_partitioned
 from arti.views.python import PythonBuiltin
 
 
 def _read_json_literal(partition: StringLiteralPartition) -> Any:
-    if partition.value is None:
-        raise _not_written_err
+    # Though we take in a Partition (which has `value` as optional), we should be operating within a
+    # Snapshot, which will ensure the `value` is set as part of
+    # StringLiteralPartition.compute_content_fingerprint.
+    assert partition.value is not None
     return json.loads(partition.value)
 
 

--- a/src/arti/partitions/__init__.py
+++ b/src/arti/partitions/__init__.py
@@ -81,53 +81,53 @@ class DateField(PartitionField):
     default_components: ClassVar[frozendict[str, str]] = frozendict(Y="Y", m="m:02", d="d:02")
     matching_type = Date
 
-    key: date
+    value: date
 
     @field_component
     def Y(self) -> int:
-        return self.key.year
+        return self.value.year
 
     @field_component
     def m(self) -> int:
-        return self.key.month
+        return self.value.month
 
     @field_component
     def d(self) -> int:
-        return self.key.day
+        return self.value.day
 
     @field_component
     def iso(self) -> str:
-        return self.key.isoformat()
+        return self.value.isoformat()
 
     @classmethod
     def from_components(cls, **components: str) -> PartitionField:
         names = set(components)
-        if names == {"key"}:
-            return cls(key=date.fromisoformat(components["key"]))
+        if names == {"value"}:
+            return cls(value=date.fromisoformat(components["value"]))
         if names == {"iso"}:
-            return cls(key=date.fromisoformat(components["iso"]))
+            return cls(value=date.fromisoformat(components["iso"]))
         if names == {"Y", "m", "d"}:
-            return cls(key=date(*[int(components[k]) for k in ("Y", "m", "d")]))
+            return cls(value=date(*[int(components[k]) for k in ("Y", "m", "d")]))
         return super().from_components(**components)
 
 
 class _IntField(PartitionField):
     _abstract_ = True
-    default_components: ClassVar[frozendict[str, str]] = frozendict(key="key")
+    default_components: ClassVar[frozendict[str, str]] = frozendict(value="value")
 
-    key: int
+    value: int
 
     @field_component
     def hex(self) -> str:
-        return hex(self.key)
+        return hex(self.value)
 
     @classmethod
     def from_components(cls, **components: str) -> PartitionField:
         names = set(components)
-        if names == {"key"}:
-            return cls(key=int(components["key"]))
+        if names == {"value"}:
+            return cls(value=int(components["value"]))
         if names == {"hex"}:
-            return cls(key=int(components["hex"], base=16))
+            return cls(value=int(components["hex"], base=16))
         return super().from_components(**components)
 
 
@@ -148,15 +148,15 @@ class Int64Field(_IntField):
 
 
 class NullField(PartitionField):
-    default_components: ClassVar[frozendict[str, str]] = frozendict(key="key")
+    default_components: ClassVar[frozendict[str, str]] = frozendict(value="value")
     matching_type = Null
 
-    key: None = None
+    value: None = None
 
     @classmethod
     def from_components(cls, **components: str) -> PartitionField:
-        if set(components) == {"key"}:
-            if components["key"] != "None":
+        if set(components) == {"value"}:
+            if components["value"] != "None":
                 raise ValueError(f"'{cls.__name__}' can only be used with 'None'!")
             return cls()
         return super().from_components(**components)

--- a/src/arti/storage/google/cloud/storage.py
+++ b/src/arti/storage/google/cloud/storage.py
@@ -49,8 +49,10 @@ class GCSFile(_GCSMixin, Storage[GCSFilePartition]):
             paths, spec=spec, key_types=self.key_types, input_fingerprints=input_fingerprints
         )
         return tuple(
-            self.generate_partition(input_fingerprint=input_fingerprint, keys=keys)
-            for (bucket, path), (input_fingerprint, keys) in {
+            self.generate_partition(
+                input_fingerprint=input_fingerprint, partition_key=partition_key
+            )
+            for (bucket, path), (input_fingerprint, partition_key) in {
                 tuple(path.split("/", 1)): metadata for path, metadata in path_metadata.items()
             }.items()
         )

--- a/src/arti/storage/google/cloud/storage.py
+++ b/src/arti/storage/google/cloud/storage.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 from gcsfs import GCSFileSystem
 
-from arti import Fingerprint, InputFingerprints, Storage, StoragePartition
+from arti import (
+    Fingerprint,
+    InputFingerprints,
+    Storage,
+    StoragePartition,
+    StoragePartitionSnapshots,
+)
 from arti.internal.models import Model
 from arti.storage._internal import parse_spec, spec_to_wildcard
 
@@ -38,7 +44,7 @@ class GCSFile(_GCSMixin, Storage[GCSFilePartition]):
 
     def discover_partitions(
         self, input_fingerprints: InputFingerprints = InputFingerprints()
-    ) -> tuple[GCSFilePartition, ...]:
+    ) -> StoragePartitionSnapshots:
         # NOTE: The bucket/path must *already* have any graph tags resolved, otherwise they will be try to be parsed as
         # partition keys.
         spec = f"{self.bucket}/{self.path}"  # type: ignore[operator] # likely some pydantic.mypy bug
@@ -51,7 +57,7 @@ class GCSFile(_GCSMixin, Storage[GCSFilePartition]):
         return tuple(
             self.generate_partition(
                 input_fingerprint=input_fingerprint, partition_key=partition_key
-            )
+            ).snapshot()
             for (bucket, path), (input_fingerprint, partition_key) in {
                 tuple(path.split("/", 1)): metadata for path, metadata in path_metadata.items()
             }.items()

--- a/src/arti/storage/literal.py
+++ b/src/arti/storage/literal.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
-from arti.fingerprints import Fingerprint
-from arti.partitions import InputFingerprints, PartitionKey
-from arti.storage import Storage, StoragePartition
+from arti import (
+    Fingerprint,
+    InputFingerprints,
+    PartitionKey,
+    Storage,
+    StoragePartition,
+    StoragePartitionSnapshots,
+)
 
 _not_written_err = FileNotFoundError("Literal has not been written yet")
 
@@ -25,7 +30,7 @@ class StringLiteral(Storage[StringLiteralPartition]):
 
     def discover_partitions(
         self, input_fingerprints: InputFingerprints = InputFingerprints()
-    ) -> tuple[StringLiteralPartition, ...]:
+    ) -> StoragePartitionSnapshots:
         if input_fingerprints and self.value is not None:
             raise ValueError(
                 f"Literal storage cannot have a `value` preset ({self.value}) for a Producer output"
@@ -40,7 +45,7 @@ class StringLiteral(Storage[StringLiteralPartition]):
         return tuple(
             self.generate_partition(
                 input_fingerprint=input_fingerprint, partition_key=partition_key
-            )
+            ).snapshot()
             for partition_key, input_fingerprint in (
                 input_fingerprints or {PartitionKey(): None}
             ).items()

--- a/src/arti/storage/literal.py
+++ b/src/arti/storage/literal.py
@@ -38,6 +38,10 @@ class StringLiteral(Storage[StringLiteralPartition]):
         if self.value is None:
             return ()
         return tuple(
-            self.generate_partition(input_fingerprint=input_fingerprint, keys=keys)
-            for keys, input_fingerprint in (input_fingerprints or {PartitionKey(): None}).items()
+            self.generate_partition(
+                input_fingerprint=input_fingerprint, partition_key=partition_key
+            )
+            for partition_key, input_fingerprint in (
+                input_fingerprints or {PartitionKey(): None}
+            ).items()
         )

--- a/src/arti/storage/local.py
+++ b/src/arti/storage/local.py
@@ -5,9 +5,13 @@ import tempfile
 from glob import glob
 from pathlib import Path
 
-from arti.fingerprints import Fingerprint
-from arti.partitions import InputFingerprints
-from arti.storage import Storage, StoragePartition
+from arti import (
+    Fingerprint,
+    InputFingerprints,
+    Storage,
+    StoragePartition,
+    StoragePartitionSnapshots,
+)
 from arti.storage._internal import parse_spec, spec_to_wildcard
 
 
@@ -39,7 +43,7 @@ class LocalFile(Storage[LocalFilePartition]):
 
     def discover_partitions(
         self, input_fingerprints: InputFingerprints = InputFingerprints()
-    ) -> tuple[LocalFilePartition, ...]:
+    ) -> StoragePartitionSnapshots:
         wildcard = spec_to_wildcard(self.path, self.key_types)
         paths = set(glob(wildcard))
         path_metadata = parse_spec(
@@ -48,7 +52,7 @@ class LocalFile(Storage[LocalFilePartition]):
         return tuple(
             self.generate_partition(
                 input_fingerprint=input_fingerprint, partition_key=partition_key
-            )
+            ).snapshot()
             for path, (input_fingerprint, partition_key) in path_metadata.items()
         )
 

--- a/src/arti/storage/local.py
+++ b/src/arti/storage/local.py
@@ -46,8 +46,10 @@ class LocalFile(Storage[LocalFilePartition]):
             paths, spec=self.path, key_types=self.key_types, input_fingerprints=input_fingerprints
         )
         return tuple(
-            self.generate_partition(input_fingerprint=input_fingerprint, keys=keys)
-            for path, (input_fingerprint, keys) in path_metadata.items()
+            self.generate_partition(
+                input_fingerprint=input_fingerprint, partition_key=partition_key
+            )
+            for path, (input_fingerprint, partition_key) in path_metadata.items()
         )
 
     @classmethod

--- a/tests/arti/artifacts/test_artifact.py
+++ b/tests/arti/artifacts/test_artifact.py
@@ -149,7 +149,7 @@ def test_Artifact_storage_path_resolution() -> None:
         format: Format = DummyFormat()
         storage: S
 
-    assert A(storage=S()).storage.key == "test-a_key={a.key}"
+    assert A(storage=S()).storage.key == "test-a_value={a.value}"
 
 
 def test_Artifact_pickle() -> None:

--- a/tests/arti/dummies.py
+++ b/tests/arti/dummies.py
@@ -14,6 +14,7 @@ from arti import (
     Statistic,
     Storage,
     StoragePartition,
+    StoragePartitionSnapshots,
     Type,
     TypeSystem,
     View,
@@ -59,12 +60,12 @@ class DummyStorage(Storage[DummyPartition]):
 
     def discover_partitions(
         self, input_fingerprints: InputFingerprints = InputFingerprints()
-    ) -> tuple[DummyPartition, ...]:
+    ) -> StoragePartitionSnapshots:
         if self.key_types != PartitionKeyTypes():
             raise NotImplementedError()
         if input_fingerprints is not None and input_fingerprints != InputFingerprints():
             raise NotImplementedError()
-        return (self.generate_partition(),)
+        return (self.generate_partition().snapshot(),)
 
 
 @io.register_reader

--- a/tests/arti/graphs/test_graph.py
+++ b/tests/arti/graphs/test_graph.py
@@ -389,7 +389,7 @@ def test_Graph_read_write(tmp_path: Path) -> None:
     assert isinstance(storage_partition, LocalFilePartition)
     assert storage_partition.content_fingerprint is not None
     assert storage_partition.input_fingerprint is None
-    assert storage_partition.keys == PartitionKey()
+    assert storage_partition.partition_key == PartitionKey()
     assert storage_partition.path.endswith(i.format.extension)
 
     # Once snapshotted, writing to the raw Artifacts would result in a different snapshot.

--- a/tests/arti/internal/test_type_hints.py
+++ b/tests/arti/internal/test_type_hints.py
@@ -5,6 +5,7 @@ import pytest
 
 from arti.internal.type_hints import (
     NoneType,
+    assert_all_instances,
     get_class_type_vars,
     get_item_from_annotated,
     is_optional_hint,
@@ -25,6 +26,12 @@ class MyTypedDict(TypedDict):
 MyTupleVar = TypeVar("MyTupleVar", bound=MyTuple)
 TupleVar = TypeVar("TupleVar", bound=tuple)  # type: ignore[type-arg]
 UnboundVar = TypeVar("UnboundVar")
+
+
+def test_assert_all_instances() -> None:
+    assert_all_instances([1, 2, 3], type=int)
+    with pytest.raises(TypeError, match="Expected int instances"):
+        assert_all_instances([1, 2, 3, "4"], type=int)
 
 
 def test_get_class_type_vars() -> None:

--- a/tests/arti/io/test_gcs_io.py
+++ b/tests/arti/io/test_gcs_io.py
@@ -39,8 +39,8 @@ def test_gcsfile_io_partitioned(gcs_bucket: str, format: Format) -> None:
     a = PartitionedNum(format=format, storage=GCSFile(bucket=gcs_bucket, path="{i.key}"))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
-            keys=PartitionKey(i=Int64Field(key=i)),
             input_fingerprint=None,
+            partition_key=PartitionKey(i=Int64Field(key=i)),
             with_content_fingerprint=False,
         ): {"i": i}
         for i in [1, 2]

--- a/tests/arti/io/test_gcs_io.py
+++ b/tests/arti/io/test_gcs_io.py
@@ -2,7 +2,14 @@ from typing import Annotated
 
 import pytest
 
-from arti import Format, PartitionKey, StoragePartition, StoragePartitions, View, io
+from arti import (
+    Format,
+    PartitionKey,
+    StoragePartition,
+    StoragePartitionSnapshots,
+    View,
+    io,
+)
 from arti.formats.json import JSON
 from arti.formats.pickle import Pickle
 from arti.partitions import Int64Field
@@ -20,14 +27,12 @@ def test_gcsfile_io(gcs_bucket: str, format: Format) -> None:
     a, n = Num(format=format, storage=GCSFile(bucket=gcs_bucket, path="file")), 5
     view = View.from_annotation(Annotated[int, a.type], mode="READWRITE")
 
-    io.write(
-        n, a.type, a.format, a.storage.generate_partition(with_content_fingerprint=False), view=view
-    )
+    io.write(n, a.type, a.format, a.storage.generate_partition(), view=view)
     partitions = a.storage.discover_partitions()
     assert len(partitions) == 1
     assert io.read(a.type, a.format, partitions, view=view) == n
     with pytest.raises(FileNotFoundError, match="No data"):
-        io.read(a.type, a.format, StoragePartitions(), view=view)
+        io.read(a.type, a.format, StoragePartitionSnapshots(), view=view)
     with pytest.raises(
         ValueError, match="Multiple partitions can only be read into a partitioned Collection, not"
     ):
@@ -39,15 +44,13 @@ def test_gcsfile_io_partitioned(gcs_bucket: str, format: Format) -> None:
     a = PartitionedNum(format=format, storage=GCSFile(bucket=gcs_bucket, path="{i.value}"))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
-            input_fingerprint=None,
-            partition_key=PartitionKey(i=Int64Field(value=i)),
-            with_content_fingerprint=False,
+            input_fingerprint=None, partition_key=PartitionKey(i=Int64Field(value=i))
         ): {"i": i}
         for i in [1, 2]
     }
     view = View.from_annotation(Annotated[list, a.type], mode="READWRITE")  # type: ignore[operator] # likely some pydantic.mypy bug
     for partition, record in data.items():
         io.write([record], a.type, a.format, partition, view=view)  # type: ignore[operator] # likely some pydantic.mypy bug
-    assert {p.with_content_fingerprint() for p in data} == set(a.storage.discover_partitions())
+    assert {p.snapshot() for p in data} == set(a.storage.discover_partitions())
     for partition, record in data.items():
-        assert io.read(a.type, a.format, [partition], view=view) == [record]  # type: ignore[operator] # likely some pydantic.mypy bug
+        assert io.read(a.type, a.format, (partition.snapshot(),), view=view) == [record]  # type: ignore[operator] # likely some pydantic.mypy bug

--- a/tests/arti/io/test_gcs_io.py
+++ b/tests/arti/io/test_gcs_io.py
@@ -36,11 +36,11 @@ def test_gcsfile_io(gcs_bucket: str, format: Format) -> None:
 
 @pytest.mark.parametrize("format", [JSON(), Pickle()])
 def test_gcsfile_io_partitioned(gcs_bucket: str, format: Format) -> None:
-    a = PartitionedNum(format=format, storage=GCSFile(bucket=gcs_bucket, path="{i.key}"))
+    a = PartitionedNum(format=format, storage=GCSFile(bucket=gcs_bucket, path="{i.value}"))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
             input_fingerprint=None,
-            partition_key=PartitionKey(i=Int64Field(key=i)),
+            partition_key=PartitionKey(i=Int64Field(value=i)),
             with_content_fingerprint=False,
         ): {"i": i}
         for i in [1, 2]

--- a/tests/arti/io/test_literal_io.py
+++ b/tests/arti/io/test_literal_io.py
@@ -18,32 +18,33 @@ def test_stringliteral_io() -> None:
     a = Num(format=JSON(), storage=StringLiteral(id="test", value=json.dumps(n)))
     view = View.from_annotation(int, mode="READWRITE")
 
-    partitions = a.storage.discover_partitions()
-    assert len(partitions) == 1
-    partition = partitions[0]
+    snapshots = a.storage.discover_partitions()
+    assert len(snapshots) == 1
+    partition = snapshots[0].storage_partition
     assert isinstance(partition, StringLiteralPartition)
     assert partition.value == json.dumps(n)
 
-    assert io.read(a.type, a.format, partitions, view=view) == n
+    assert io.read(a.type, a.format, snapshots, view=view) == n
     # Read "partitioned" literal
     assert io.read(
         Collection(element=Struct(fields={"a": Int64()}), partition_by=("a",)),
         a.format,
-        [
-            partition.copy(update={"value": '[{"a": 1}]'}),
-            partition.copy(update={"value": '[{"a": 2}]'}),
-        ],
+        tuple(
+            p.snapshot()
+            for p in [
+                partition.copy(update={"value": '[{"a": 1}]'}),
+                partition.copy(update={"value": '[{"a": 2}]'}),
+            ]
+        ),
         view=view,
     ) == [{"a": 1}, {"a": 2}]
-    # Check that read with value=None fails
-    with pytest.raises(FileNotFoundError, match="Literal has not been written yet"):
-        io.read(a.type, a.format, [StringLiteralPartition(id="junk", storage=a.storage)], view=view)
 
     # Test write
     unwritten = StringLiteralPartition(id="junk", storage=a.storage)
-    new = io.write(10, a.type, a.format, unwritten, view=view)
-    assert isinstance(new, StringLiteralPartition)
-    assert new.value == json.dumps(10)
+    new_snapshot = io.write(10, a.type, a.format, unwritten, view=view)
+    new_partition = new_snapshot.storage_partition
+    assert isinstance(new_partition, StringLiteralPartition)
+    assert new_partition.value == json.dumps(10)
     assert partition.value == json.dumps(n)  # Confirm no mutation
     with pytest.raises(ValueError, match="Literals with a value already set cannot be written"):
-        io.write(10, a.type, a.format, new, view=view)
+        io.write(10, a.type, a.format, new_partition, view=view)

--- a/tests/arti/io/test_localfile_io.py
+++ b/tests/arti/io/test_localfile_io.py
@@ -3,7 +3,14 @@ from typing import Annotated
 
 import pytest
 
-from arti import Format, PartitionKey, StoragePartition, StoragePartitions, View, io
+from arti import (
+    Format,
+    PartitionKey,
+    StoragePartition,
+    StoragePartitionSnapshots,
+    View,
+    io,
+)
 from arti.formats.json import JSON
 from arti.formats.pickle import Pickle
 from arti.partitions import Int64Field
@@ -21,14 +28,12 @@ def test_localfile_io(tmp_path: Path, format: Format) -> None:
     a, n = Num(format=format, storage=LocalFile(path=str(tmp_path / "a"))), 5
     view = View.from_annotation(Annotated[int, a.type], mode="READWRITE")
 
-    io.write(
-        n, a.type, a.format, a.storage.generate_partition(with_content_fingerprint=False), view=view
-    )
+    io.write(n, a.type, a.format, a.storage.generate_partition(), view=view)
     partitions = a.storage.discover_partitions()
     assert len(partitions) == 1
     assert io.read(a.type, a.format, partitions, view=view) == n
     with pytest.raises(FileNotFoundError, match="No data"):
-        io.read(a.type, a.format, StoragePartitions(), view=view)
+        io.read(a.type, a.format, StoragePartitionSnapshots(), view=view)
     with pytest.raises(
         ValueError, match="Multiple partitions can only be read into a partitioned Collection, not"
     ):
@@ -40,15 +45,13 @@ def test_localfile_io_partitioned(tmp_path: Path, format: Format) -> None:
     a = PartitionedNum(format=format, storage=LocalFile(path=str(tmp_path / "{i.value}")))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
-            input_fingerprint=None,
-            partition_key=PartitionKey(i=Int64Field(value=i)),
-            with_content_fingerprint=False,
+            input_fingerprint=None, partition_key=PartitionKey(i=Int64Field(value=i))
         ): {"i": i}
         for i in [1, 2]
     }
     view = View.from_annotation(Annotated[list, a.type], mode="READWRITE")  # type: ignore[operator] # likely some pydantic.mypy bug
     for partition, record in data.items():
         io.write([record], a.type, a.format, partition, view=view)  # type: ignore[operator] # likely some pydantic.mypy bug
-    assert {p.with_content_fingerprint() for p in data} == set(a.storage.discover_partitions())
+    assert {p.snapshot() for p in data} == set(a.storage.discover_partitions())
     for partition, record in data.items():
-        assert io.read(a.type, a.format, [partition], view=view) == [record]  # type: ignore[operator] # likely some pydantic.mypy bug
+        assert io.read(a.type, a.format, (partition.snapshot(),), view=view) == [record]  # type: ignore[operator] # likely some pydantic.mypy bug

--- a/tests/arti/io/test_localfile_io.py
+++ b/tests/arti/io/test_localfile_io.py
@@ -40,8 +40,8 @@ def test_localfile_io_partitioned(tmp_path: Path, format: Format) -> None:
     a = PartitionedNum(format=format, storage=LocalFile(path=str(tmp_path / "{i.key}")))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
-            keys=PartitionKey(i=Int64Field(key=i)),
             input_fingerprint=None,
+            partition_key=PartitionKey(i=Int64Field(key=i)),
             with_content_fingerprint=False,
         ): {"i": i}
         for i in [1, 2]

--- a/tests/arti/io/test_localfile_io.py
+++ b/tests/arti/io/test_localfile_io.py
@@ -37,11 +37,11 @@ def test_localfile_io(tmp_path: Path, format: Format) -> None:
 
 @pytest.mark.parametrize("format", [JSON(), Pickle()])
 def test_localfile_io_partitioned(tmp_path: Path, format: Format) -> None:
-    a = PartitionedNum(format=format, storage=LocalFile(path=str(tmp_path / "{i.key}")))
+    a = PartitionedNum(format=format, storage=LocalFile(path=str(tmp_path / "{i.value}")))
     data: dict[StoragePartition, dict[str, int]] = {
         a.storage.generate_partition(
             input_fingerprint=None,
-            partition_key=PartitionKey(i=Int64Field(key=i)),
+            partition_key=PartitionKey(i=Int64Field(value=i)),
             with_content_fingerprint=False,
         ): {"i": i}
         for i in [1, 2]

--- a/tests/arti/partitions/test_partitions.py
+++ b/tests/arti/partitions/test_partitions.py
@@ -26,7 +26,7 @@ def test_PartitionField_components() -> None:
 
     components = Int8Field.components
     assert isinstance(components, frozenset)
-    assert components == {"key", "hex"}
+    assert components == {"value", "hex"}
 
     assert isinstance(Int8Field.hex, field_component)
     assert isinstance(Int8Field.hex, property)
@@ -73,7 +73,7 @@ def test_PartitionField_subclass() -> None:
 
 
 def test_DateField() -> None:
-    k = DateField(key=date(1970, 1, 1))
+    k = DateField(value=date(1970, 1, 1))
     assert k.Y == 1970
     assert k.m == 1
     assert k.d == 1
@@ -82,7 +82,7 @@ def test_DateField() -> None:
     assert k == DateField.from_components(Y="1970", m="1", d="1")
     assert k == DateField.from_components(Y="1970", m="01", d="01")
     assert k == DateField.from_components(iso="1970-01-01")
-    assert k == DateField.from_components(key="1970-01-01")
+    assert k == DateField.from_components(value="1970-01-01")
     with pytest.raises(
         NotImplementedError,
         match=re.escape("Unable to parse 'DateField' from: {'junk': 'abc'}"),
@@ -102,10 +102,10 @@ def test_DateField() -> None:
 def test_IntFields(IntKey: type[_IntField], matching_type: type[Type]) -> None:
     assert IntKey.matching_type is matching_type
 
-    k = IntKey(key=1)
+    k = IntKey(value=1)
     assert k.hex == "0x1"
 
-    assert k == IntKey.from_components(key="1")
+    assert k == IntKey.from_components(value="1")
     assert k == IntKey.from_components(hex="0x1")
 
     with pytest.raises(
@@ -117,16 +117,16 @@ def test_IntFields(IntKey: type[_IntField], matching_type: type[Type]) -> None:
 
 def test_NullField() -> None:
     k = NullField()
-    assert k.key is None
+    assert k.value is None
 
-    assert k == NullField.from_components(key="None")
+    assert k == NullField.from_components(value="None")
 
     with pytest.raises(
         NotImplementedError, match=re.escape("Unable to parse 'NullField' from: {'junk': 'abc'}")
     ):
         NullField.from_components(junk="abc")
     with pytest.raises(ValueError, match="'NullField' can only be used with 'None'!"):
-        NullField.from_components(key="abc")
+        NullField.from_components(value="abc")
 
 
 def test_PartitionKey_types_frome() -> None:

--- a/tests/arti/storage/test_gcs_storage.py
+++ b/tests/arti/storage/test_gcs_storage.py
@@ -17,14 +17,11 @@ def test_GCSFile() -> None:
 
 def test_GCSFile_discover_partitions(gcs: GCSFileSystem, gcs_bucket: str) -> None:
     storage = (
-        GCSFile(
-            bucket=gcs_bucket,
-            path="{i.key}",
-        )
+        GCSFile(bucket=gcs_bucket, path="{i.value}")
         ._visit_type(Collection(element=Struct(fields={"i": Int32()}), partition_by=("i",)))
         ._visit_format(DummyFormat())
     )
-    expected_keys = {PartitionKey(i=Int32Field(key=i)) for i in [0, 1]}
+    expected_keys = {PartitionKey(i=Int32Field(value=i)) for i in [0, 1]}
     gcs.pipe({storage.qualified_path.format(**key): b"data" for key in expected_keys})
     for partition in storage.discover_partitions():
         assert partition.partition_key in expected_keys

--- a/tests/arti/storage/test_gcs_storage.py
+++ b/tests/arti/storage/test_gcs_storage.py
@@ -25,10 +25,10 @@ def test_GCSFile_discover_partitions(gcs: GCSFileSystem, gcs_bucket: str) -> Non
         ._visit_format(DummyFormat())
     )
     expected_keys = {PartitionKey(i=Int32Field(key=i)) for i in [0, 1]}
-    gcs.pipe({storage.qualified_path.format(**keys): b"data" for keys in expected_keys})
+    gcs.pipe({storage.qualified_path.format(**key): b"data" for key in expected_keys})
     for partition in storage.discover_partitions():
-        assert partition.keys in expected_keys
-        assert partition.qualified_path == storage.qualified_path.format(**partition.keys)
+        assert partition.partition_key in expected_keys
+        assert partition.qualified_path == storage.qualified_path.format(**partition.partition_key)
         assert partition.content_fingerprint == Fingerprint.from_string(
             base64.b64encode(
                 hashlib.md5(b"data").digest()  # noqa: S324 (GCS only provides md5)

--- a/tests/arti/storage/test_literal_storage.py
+++ b/tests/arti/storage/test_literal_storage.py
@@ -11,9 +11,10 @@ from tests.arti.dummies import DummyFormat
 def test_StringLiteral() -> None:
     t, f = Int64(), DummyFormat()
     literal = StringLiteral(id="test", value="test")._visit_type(t)._visit_format(f)
-    partitions = literal.discover_partitions()
-    assert len(partitions) == 1
-    partition = partitions[0]
+    snapshots = literal.discover_partitions()
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    partition = snapshot.storage_partition
     assert isinstance(partition, StringLiteralPartition)
     assert partition.value is not None
     assert partition.value == literal.value
@@ -21,12 +22,7 @@ def test_StringLiteral() -> None:
     # Confirm value=None returns no partitions
     assert not StringLiteral(id="test")._visit_type(t)._visit_format(f).discover_partitions()
     # Confirm input_fingerprint and partition_key validators don't error for empty values
-    assert (
-        partition
-        == StringLiteralPartition(
-            id="test", value="test", storage=literal
-        ).with_content_fingerprint()
-    )
+    assert snapshot == StringLiteralPartition(id="test", value="test", storage=literal).snapshot()
     # Confirm empty value raises
     with pytest.raises(FileNotFoundError, match="Literal has not been written yet"):
         StringLiteralPartition(id="test", storage=literal).compute_content_fingerprint()

--- a/tests/arti/storage/test_literal_storage.py
+++ b/tests/arti/storage/test_literal_storage.py
@@ -20,7 +20,7 @@ def test_StringLiteral() -> None:
     assert partition.compute_content_fingerprint() == Fingerprint.from_string(partition.value)
     # Confirm value=None returns no partitions
     assert not StringLiteral(id="test")._visit_type(t)._visit_format(f).discover_partitions()
-    # Confirm keys/input_fingerprint validators don't error for empty values
+    # Confirm input_fingerprint and partition_key validators don't error for empty values
     assert (
         partition
         == StringLiteralPartition(

--- a/tests/arti/storage/test_local_storage.py
+++ b/tests/arti/storage/test_local_storage.py
@@ -29,7 +29,7 @@ def date_keys() -> list[PartitionKey]:
 def generate_partition_files(storage: LocalFile, input_fingerprints: InputFingerprints) -> None:
     for pk, input_fingerprint in input_fingerprints.items():
         partition = storage.generate_partition(
-            pk, input_fingerprint, with_content_fingerprint=False
+            input_fingerprint=input_fingerprint, partition_key=pk, with_content_fingerprint=False
         )
         partition_path = Path(partition.path)
         partition_path.parent.mkdir(parents=True)
@@ -47,9 +47,9 @@ def test_local_partitioning(tmp_path: Path, date_keys: list[PartitionKey]) -> No
     assert len(partitions) > 0
     for partition in partitions:
         assert isinstance(partition, LocalFilePartition)
-        assert set(partition.keys) == {"date"}
-        assert partition.keys in date_keys
-        assert isinstance(partition.keys["date"], DateField)
+        assert set(partition.partition_key) == {"date"}
+        assert partition.partition_key in date_keys
+        assert isinstance(partition.partition_key["date"], DateField)
 
 
 def test_local_partitioning_filtered(tmp_path: Path, date_keys: list[PartitionKey]) -> None:
@@ -76,10 +76,10 @@ def test_local_partitioning_filtered(tmp_path: Path, date_keys: list[PartitionKe
         assert len(partitions) > 0
         for partition in partitions:
             assert isinstance(partition, LocalFilePartition)
-            assert set(partition.keys) == {"date"}
-            assert partition.keys in date_keys
-            assert isinstance(partition.keys["date"], DateField)
-            assert year == partition.keys["date"].Y
+            assert set(partition.partition_key) == {"date"}
+            assert partition.partition_key in date_keys
+            assert isinstance(partition.partition_key["date"], DateField)
+            assert year == partition.partition_key["date"].Y
 
 
 def test_local_partitioning_with_input_fingerprints(
@@ -101,9 +101,9 @@ def test_local_partitioning_with_input_fingerprints(
     assert len(partitions) > 0
     for partition in partitions:
         assert isinstance(partition, LocalFilePartition)
-        assert set(partition.keys) == {"date"}
-        assert partition.keys in date_keys
-        assert isinstance(partition.keys["date"], DateField)
+        assert set(partition.partition_key) == {"date"}
+        assert partition.partition_key in date_keys
+        assert isinstance(partition.partition_key["date"], DateField)
         assert partition.input_fingerprint == input_fingerprint
 
 
@@ -126,7 +126,7 @@ def test_local_file_partition_fingerprint(tmp_path: Path) -> None:
     with path.open("w") as f:
         f.write("hello world")
     partition = LocalFilePartition(
-        keys={}, path=str(path), storage=LocalFile(path=str(path))
+        partition_key={}, path=str(path), storage=LocalFile(path=str(path))
     ).with_content_fingerprint()
     assert partition.content_fingerprint == Fingerprint.from_string(
         hashlib.sha256(text.encode()).hexdigest()

--- a/tests/arti/storage/test_local_storage.py
+++ b/tests/arti/storage/test_local_storage.py
@@ -18,10 +18,10 @@ def date_keys() -> list[PartitionKey]:
     return [
         PartitionKey(date=date_key)
         for date_key in (
-            DateField(key=date(1970, 1, 1)),
-            DateField(key=date(1970, 1, 2)),
-            DateField(key=date(1970, 1, 3)),
-            DateField(key=date(2021, 1, 1)),
+            DateField(value=date(1970, 1, 1)),
+            DateField(value=date(1970, 1, 2)),
+            DateField(value=date(1970, 1, 3)),
+            DateField(value=date(2021, 1, 1)),
         )
     ]
 

--- a/tests/arti/storage/test_storage_internal.py
+++ b/tests/arti/storage/test_storage_internal.py
@@ -227,6 +227,6 @@ def test_parse_spec(
         parse_spec({"/p/1/"}, spec="/p/{x.key}/{y.hex}", key_types=PKs)
     with pytest.raises(
         ValueError,
-        match=re.escape("Expected to find partition keys for ['x', 'y'], only found ['x']."),
+        match=re.escape("Expected to find partition fields for ['x', 'y'], only found ['x']."),
     ):
         parse_spec({"/p/1/"}, spec="/p/{x.key}/", key_types=PKs)

--- a/tests/arti/storage/test_storage_internal.py
+++ b/tests/arti/storage/test_storage_internal.py
@@ -26,7 +26,7 @@ def PKs() -> dict[str, type[PartitionField]]:
 
 @pytest.fixture()
 def spec() -> str:
-    return "/p/{x.key}/{y.hex}"
+    return "/p/{x.value}/{y.hex}"
 
 
 @pytest.fixture()
@@ -37,9 +37,9 @@ def paths() -> set[str]:
 @pytest.fixture()
 def paths_to_placeholders() -> PathPlaceholders:
     return {
-        "/p/1/0x1": (None, PartitionKey({"x": Int8Field(key=1), "y": Int8Field(key=1)})),
-        "/p/2/0x2": (None, PartitionKey({"x": Int8Field(key=2), "y": Int8Field(key=2)})),
-        "/p/3/0x3": (None, PartitionKey({"x": Int8Field(key=3), "y": Int8Field(key=3)})),
+        "/p/1/0x1": (None, PartitionKey({"x": Int8Field(value=1), "y": Int8Field(value=1)})),
+        "/p/2/0x2": (None, PartitionKey({"x": Int8Field(value=2), "y": Int8Field(value=2)})),
+        "/p/3/0x3": (None, PartitionKey({"x": Int8Field(value=3), "y": Int8Field(value=3)})),
     }
 
 
@@ -69,8 +69,8 @@ def test_FormatPlaceholder(spec: str, key: str) -> None:
 @pytest.mark.parametrize(
     ("key", "partition_key_types", "attribute"),
     [
-        ("test", PartitionKeyTypes(test=Int8Field), "key"),
         ("test", PartitionKeyTypes(test=Int8Field), "hex"),
+        ("test", PartitionKeyTypes(test=Int8Field), "value"),
     ],
 )
 def test_WildcardPlaceholder(
@@ -169,9 +169,9 @@ def test_strip_partition_indexes(spec: str, expected: str) -> None:
 
 
 def test_spec_to_wildcard(PKs: dict[str, type[PartitionField]]) -> None:
-    assert spec_to_wildcard("/p/{x.key}/", PKs) == "/p/*/"
-    assert spec_to_wildcard("/p/{x.key[5]}/", PKs) == "/p/5/"
-    assert spec_to_wildcard("/p/{x.key[5]}/{y.hex}/", PKs) == "/p/5/*/"
+    assert spec_to_wildcard("/p/{x.value}/", PKs) == "/p/*/"
+    assert spec_to_wildcard("/p/{x.value[5]}/", PKs) == "/p/5/"
+    assert spec_to_wildcard("/p/{x.value[5]}/{y.hex}/", PKs) == "/p/5/*/"
 
 
 def test_extract_placeholders(
@@ -192,7 +192,7 @@ def test_extract_placeholders(
         for path in paths
     } == paths_to_placeholders
     with pytest.raises(
-        ValueError, match=re.escape("Unable to parse 'fake' with '/p/{x.key}/{y.hex}'.")
+        ValueError, match=re.escape("Unable to parse 'fake' with '/p/{x.value}/{y.hex}'.")
     ):
         extract_placeholders(
             key_types=PKs,
@@ -222,11 +222,11 @@ def test_parse_spec(
     assert pks == paths_to_placeholders
 
     with pytest.raises(
-        ValueError, match=re.escape("Unable to parse '/p/1/' with '/p/{x.key}/{y.hex}'")
+        ValueError, match=re.escape("Unable to parse '/p/1/' with '/p/{x.value}/{y.hex}'")
     ):
-        parse_spec({"/p/1/"}, spec="/p/{x.key}/{y.hex}", key_types=PKs)
+        parse_spec({"/p/1/"}, spec="/p/{x.value}/{y.hex}", key_types=PKs)
     with pytest.raises(
         ValueError,
         match=re.escape("Expected to find partition fields for ['x', 'y'], only found ['x']."),
     ):
-        parse_spec({"/p/1/"}, spec="/p/{x.key}/", key_types=PKs)
+        parse_spec({"/p/1/"}, spec="/p/{x.value}/", key_types=PKs)

--- a/tests/arti/views/test_python.py
+++ b/tests/arti/views/test_python.py
@@ -35,7 +35,7 @@ def test_python_View() -> None:
             data = read(
                 type_=view.type,
                 format=test_format,
-                storage_partitions=(test_storage_partition,),
+                storage_partition_snapshots=(test_storage_partition.snapshot(),),
                 view=view,
             )
             assert data == val


### PR DESCRIPTION
# Description

- **Rename StoragePartition.keys to StoragePartition.partition_key**
- **Rename PartitionField subclass key fields to value**
- **Add StoragePartitionSnapshot to disambiguate fingerprinted partitions**

---

Thinking about this a bit more, it might make sense to make `StoragePartitionSnapshot` a base class or a Generic so that we can pass them into the `io.read` handlers rather than just the `StoragePartition`s (as is, the multiple dispatch wouldn't be able to determine the sub-type from just the `StoragePartitionSnapshot` class). Using a Generic wasn't ~possible~ easy before because python typing (or just mypy) didn't (doesn't?) support things like `tuple[StoragePartitionSnapshot[T], ...]` but I think that's possible now.

Perhaps we can do that in a follow up.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in upstream modules
